### PR TITLE
Add failsafe to oxide.service

### DIFF
--- a/assets/etc/systemd/system/oxide.service
+++ b/assets/etc/systemd/system/oxide.service
@@ -5,7 +5,8 @@ Description=oxide launcher
 After=home.mount
 
 [Service]
-ExecStart=/opt/bin/oxide
+# Run /opt/bin/oxide if found, if not start xochitl instead (failsafe)
+ExecStart=/bin/sh -c 'if [ -f /opt/bin/oxide ]; then /opt/bin/oxide; else systemctl start xochitl; fi'
 
 [Install]
 WantedBy=multi-user.target

--- a/assets/etc/systemd/system/oxide.service
+++ b/assets/etc/systemd/system/oxide.service
@@ -3,10 +3,10 @@ Description=oxide launcher
 #StartLimitIntervalSec=600
 #StartLimitBurst=4
 After=home.mount
+OnFailure=xochitl.service
 
 [Service]
-# Run /opt/bin/oxide if found, if not start xochitl instead (failsafe)
-ExecStart=/bin/sh -c 'if [ -f /opt/bin/oxide ]; then /opt/bin/oxide; else systemctl start xochitl; fi'
+ExecStart=/opt/bin/oxide
 
 [Install]
 WantedBy=multi-user.target

--- a/assets/etc/systemd/system/oxide.service
+++ b/assets/etc/systemd/system/oxide.service
@@ -1,14 +1,14 @@
 [Unit]
 Description=oxide launcher
-#StartLimitIntervalSec=600
-#StartLimitBurst=4
 After=home.mount
+StartLimitInterval=30
+StartLimitBurst=5
 OnFailure=xochitl.service
 
 [Service]
 ExecStart=/opt/bin/oxide
+Restart=on-failure
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target
-
-


### PR DESCRIPTION
I'm not very comfortable having a service starting instead of xochitl that might fail and give the impression of a soft bricked device.

For example, the opt mount might for some reason mount a bit later or the user uninstalls the app manually and forgets the systemd services. In such cases this commit will just have xochitl starting as usual.

I added the file check to prevent the xochitl of starting should oxide just crash. It only protects against the missing binary itself. Having a crash start xochitl would seem weird to me.

I also used the traditional (longer) if-else-syntax instead of `[ cond ] && true-expr || false-expr` because `true-expr` returning a non-zero exit-code (e.g. crash) would still trigger the `false-expr`.