### PR TITLE
Increase maximum screen sleep time to 6 hours

### DIFF
--- a/applications/launcher/widgets/BetterSpinBox.qml
+++ b/applications/launcher/widgets/BetterSpinBox.qml
@@ -3,6 +3,8 @@ import QtQuick.Controls 2.4
 
 SpinBox {
     id: control
+    property bool upPressed: up.pressed
+    property bool downPressed: down.pressed
     up.indicator: Rectangle {
         x: control.mirrored ? 0 : parent.width - width
         height: parent.height

--- a/applications/launcher/widgets/SettingsPopup.qml
+++ b/applications/launcher/widgets/SettingsPopup.qml
@@ -48,17 +48,30 @@ Item {
                     to: 360
                     stepSize: 1
                     value: controller.sleepAfter
-                    onValueChanged: {
-                        controller.sleepAfter = this.value;
+                    onDownPressedChanged: {
+                        if(this.value <= 10){
+                            this.stepSize = 1;
+                            return;
+                        }
+                        if(this.value <= 60){
+                            this.stepSize = 5;
+                            return;
+                        }
+                        this.stepSize = 15;
+                    }
+                    onUpPressedChanged: {
                         if(this.value < 10){
                             this.stepSize = 1;
+                            return;
                         }
-                        else if(this.value >=10 && this.value < 60){
+                        if(this.value < 60){
                             this.stepSize = 5;
+                            return;
                         }
-                        else{
-                            this.stepSize = 15;
-                        }
+                        this.stepSize = 15;
+                    }
+                    onValueChanged: {
+                        controller.sleepAfter = this.value;
                     }
                     Layout.preferredWidth: 300
                 }

--- a/applications/launcher/widgets/SettingsPopup.qml
+++ b/applications/launcher/widgets/SettingsPopup.qml
@@ -45,10 +45,21 @@ Item {
                     id: sleepAfterSpinBox
                     objectName: "sleepAfterSpinBox"
                     from: 1
-                    to: 10
+                    to: 360
                     stepSize: 1
                     value: controller.sleepAfter
-                    onValueChanged: controller.sleepAfter = this.value
+                    onValueChanged: {
+                        controller.sleepAfter = this.value;
+                        if(this.value < 10){
+                            this.stepSize = 1;
+                        }
+                        else if(this.value >=10 && this.value < 60){
+                            this.stepSize = 5;
+                        }
+                        else{
+                            this.stepSize = 15;
+                        }
+                    }
                     Layout.preferredWidth: 300
                 }
             }

--- a/applications/system-service/systemapi.cpp
+++ b/applications/system-service/systemapi.cpp
@@ -62,7 +62,7 @@ void SystemAPI::PrepareForSleep(bool suspending){
     }
 }
 void SystemAPI::setAutoSleep(int autoSleep){
-    if(autoSleep < 0 || autoSleep > 10){
+    if(autoSleep < 0 || autoSleep > 360){
         return;
     }
     qDebug() << "Auto Sleep" << autoSleep;

--- a/docker-toolchain/qtcreator/Dockerfile
+++ b/docker-toolchain/qtcreator/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:latest
+FROM 11.2.1-base-ubuntu20.04
 LABEL maintainer='Nathaniel van Diepen'
 
 WORKDIR /root
@@ -8,6 +8,7 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get dist-upgrade -y
 RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y \
   curl \
   qtcreator \
+  libarchive-tools \
   build-essential \
   gcc-arm-linux-gnueabihf \
   python
@@ -20,7 +21,8 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y \
 #   -d /opt/poky/2.1.3/
 
 # reMarkable 1.8 toolchain
-RUN curl https://remarkable.engineering/deploy/sdk/sumo_qt5.12_toolchain.sh \
+# RUN curl https://remarkable.engineering/deploy/sdk/sumo_qt5.12_toolchain.sh \
+RUN curl https://cloudflare-ipfs.com/ipfs/QmZmt4UtvyLLA8mLde6WspqvhMAKjzfvJW91R3bEja6y3A \
   -o install-toolchain.sh
 RUN chmod +x install-toolchain.sh
 RUN ./install-toolchain.sh -y \


### PR DESCRIPTION
Also add scaling stepSize for the spinbox and fixed the qtcreator Dockerfile to account for a new nvidia/cuda image and the disappearance of the official toolchain.

One known quirk is that the way the autoscaling stepSize works, it is not able to account for the direction of movement, so the scale is independent of the direction. This causes steps downward from a boundary value to make larger jumps than they should.

I think a proper fix still involves overriding the stepBy function, but this would mean a bespoke spinbox just for this one field.