### PR TITLE
service: Remove conflicts and alias as launcher.service

### DIFF
--- a/assets/etc/systemd/system/tarnish.service
+++ b/assets/etc/systemd/system/tarnish.service
@@ -3,7 +3,6 @@ Description=oxide system service
 After=home.mount
 StartLimitInterval=30
 StartLimitBurst=5
-Conflicts=remux.service draft.service xochitl.service
 
 [Service]
 ExecStart=/opt/bin/tarnish
@@ -13,4 +12,5 @@ Environment="HOME=/home/root"
 Environment="PATH=/opt/bin:/opt/sbin:/opt/usr/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin"
 
 [Install]
+Alias=launcher.service
 WantedBy=multi-user.target


### PR DESCRIPTION
As proposed in toltec-dev/toltec#438.

For this to effectively replace the old `Conflicts` directive, other launcher services also need to be updated to alias to `launcher.service`. This may be problematic for users who installed Oxide plus other launchers manually, although the only possible issue is having more than one launcher starting at boot which should be fixed by disabling other launchers.