### PR TITLE
Increase GESTURE_LENGTH to 936

### DIFF
--- a/applications/system-service/systemapi.h
+++ b/applications/system-service/systemapi.h
@@ -15,7 +15,7 @@
 #include "login1_interface.h"
 
 
-#define GESTURE_LENGTH 30
+#define GESTURE_LENGTH 936
 
 #define systemAPI SystemAPI::singleton()
 


### PR DESCRIPTION
Many reMarkable apps (including Xochitl) have gesture conflicts with tarnish. The current GESTURE_LENGTH of 30 is in my opinion too low, making it difficult to trigger app gestures without also triggering tarnish gestures. For example, swiping down to open the menu in KOReader often triggers the tarnish gestures toggle.

Longer gestures prevent accidental triggers and allow application gestures to be triggered independently of tarnish gestures. I chose a length of 936 because it is 2/3rds the horizontal resolution of the reMarkable 2, and gestures that long are likely intentional.