### PR TITLE
Fix auto sleep setting bugs

### DIFF
--- a/applications/launcher/controller.cpp
+++ b/applications/launcher/controller.cpp
@@ -216,7 +216,6 @@ QList<QObject*> Controller::getApps(){
 void Controller::setAutoStartApplication(QString autoStartApplication){
     m_autoStartApplication = autoStartApplication;
     emit autoStartApplicationChanged(autoStartApplication);
-    saveSettings();
 }
 AppItem* Controller::getApplication(QString name){
     for(auto app : applications){

--- a/applications/launcher/main.qml
+++ b/applications/launcher/main.qml
@@ -316,7 +316,7 @@ ApplicationWindow {
                             }
                             var name = itemInfo.model.name
                             controller.autoStartApplication = controller.autoStartApplication !== name ? name : "";
-
+                            controller.saveSettings();
                         }
                     }
                 }

--- a/applications/launcher/widgets/SettingsPopup.qml
+++ b/applications/launcher/widgets/SettingsPopup.qml
@@ -28,7 +28,10 @@ Item {
                 BetterCheckBox {
                     tristate: false
                     checkState: controller.automaticSleep ? Qt.Checked : Qt.Unchecked
-                    onClicked: controller.automaticSleep = this.checkState === Qt.Checked
+                    onClicked: {
+                        controller.automaticSleep = this.checkState === Qt.Checked
+                        controller.sleepAfter = sleepAfterSpinBox.value
+                    }
                     Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
                     Layout.fillWidth: false
                 }


### PR DESCRIPTION
This fixes two bugs:

* loadSettings indirectly calls saveSettings, breaking reset for the sleep settings.
* The auto sleep setting is not saved unless the sleepAfter SpinBox is modified