### PR TITLE
Add templates dir to xochitl.oxide

### DIFF
--- a/assets/opt/usr/share/applications/xochitl.oxide
+++ b/assets/opt/usr/share/applications/xochitl.oxide
@@ -10,6 +10,7 @@
         "/home/root",
         "/tmp/runtime-root",
         "/usr/share",
+        "/usr/share/remarkable/templates",
         "/run/udev",
         "/run/dbus",
         "/run/systemd/resolve",


### PR DESCRIPTION
This fixes an issue where xochitl would have trouble loading custom templates when running under Oxide.

In chat, we discussed that xochitl should probably have access to everything under /usr/share/remarkable, but adding that directory doesn't resolve the bug. It's possible that the correct fix is making the directory permissions recursive, since /usr/share is already present in the list.

However, this does resolve the template issue for me... so may be worth the merge in any case?