### PR TITLE
Add /opt/etc directory to xochitl application

### DIFF
--- a/assets/opt/usr/share/applications/xochitl.oxide
+++ b/assets/opt/usr/share/applications/xochitl.oxide
@@ -8,6 +8,7 @@
     "directories": [
         "/etc",
         "/home/root",
+        "/opt/etc",
         "/tmp/runtime-root",
         "/usr/share",
         "/usr/share/remarkable/templates",


### PR DESCRIPTION
Fixing #228. This directory needs to be visible for rM2 users who have a custom `/opt/etc/rm2fb.conf` - usually due to running a tablet version that rm2fb that does not support yet.