### PR TITLE
shared: Don't check the Cyttsp5 REL bit

### DIFF
--- a/shared/devicesettings.cpp
+++ b/shared/devicesettings.cpp
@@ -45,7 +45,7 @@ DeviceSettings::DeviceSettings(): _deviceType(DeviceType::RM1) {
                 continue;
             }
         }
-        if(test_bit(EV_REL, bit) && checkBitSet(fd, EV_ABS, ABS_MT_SLOT)) {
+        if (checkBitSet(fd, EV_ABS, ABS_MT_SLOT)) {
             qDebug() << "    Touch input device detected";
             touchPath = fullPath.toStdString();
             continue;


### PR DESCRIPTION
The reMarkable vendor kernel incorrectly sets the REL bit for the Cyprus
Cyttsp5 driver. The check in Oxide currently relies on this bug.

The in progress upstream Cyttsp5 kernel driver doesn't set the REL bit.
This patch removes the check from Oxide so that it works on both the
mainline kernel as well as the vendor kernel.

Signed-off-by: Alistair Francis <alistair@alistair23.me>