### PR TITLE
Generate application registration for appload apps, fix fake rm2fb

### DIFF
--- a/VELBUILD
+++ b/VELBUILD
@@ -76,6 +76,8 @@ package() {
         home/root/.local/share/applications/xochitl.oxide
     install -o root -g root -Dm644 -t "$pkgdir"/home/root/.local/share/icons/oxide/48x48/apps \
         home/root/.local/share/icons/oxide/48x48/apps/xochitl.png
+    install -o root -g root -Dm755 -t "$pkgdir"/home/root/.vellum/share/oxide/libexec \
+        home/root/.vellum/share/oxide/libexec/runner
     # Task manager
     install -o root -g root -Dm755 -t "$pkgdir"/home/root/.vellum/bin \
         home/root/.vellum/bin/erode

--- a/applications/system-service/runner
+++ b/applications/system-service/runner
@@ -1,8 +1,3 @@
 #!/bin/sh
 set -e
-case "$(basename "$EXECUTABLE")" in
-puzzles)
-  export OXIDE_PRELOAD_FORCE_RM1=1
-  ;;
-esac
 eval "exec blight-client \"$EXECUTABLE\" $ARGUMENTS"

--- a/applications/system-service/runner
+++ b/applications/system-service/runner
@@ -1,3 +1,4 @@
 #!/bin/sh
 set -e
-eval "exec blight-client \"$EXECUTABLE\" $ARGUMENTS"
+eval "set -- $ARGUMENTS"
+exec blight-client "$EXECUTABLE" "$@"

--- a/applications/system-service/runner
+++ b/applications/system-service/runner
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+case "$(basename "$EXECUTABLE")" in
+puzzles)
+  export OXIDE_PRELOAD_FORCE_RM1=1
+  ;;
+esac
+eval "exec blight-client \"$EXECUTABLE\" $ARGUMENTS"

--- a/applications/system-service/system-service.pro
+++ b/applications/system-service/system-service.pro
@@ -48,6 +48,10 @@ launcherctl.files = ../../assets/opt/share/launcherctl/oxide
 launcherctl.path = $$SHARE_INSTALL_PATH/launcherctl/
 INSTALLS += launcherctl
 
+runner.files = runner
+runner.path = $$ROOT_INSTALL_PATH/share/oxide/libexec/
+INSTALLS += runner
+
 applications.files = \
     ../../assets/opt/usr/share/applications/xochitl.oxide \
     ../../assets/opt/usr/share/applications/xovi.oxide
@@ -95,6 +99,7 @@ DISTFILES += \
     fi.w1.wpa_supplicant1.xml \
     generate_xml.sh \
     org.freedesktop.login1.xml \
+    runner \
     ../../assets/etc/dbus-1/system.d/codes.eeems.oxide.conf \
     ../../assets/etc/systemd/system/tarnish.service \
     ../../assets/opt/usr/share/applications/xochitl.oxide \

--- a/applications/update-desktop-database/main.cpp
+++ b/applications/update-desktop-database/main.cpp
@@ -176,6 +176,159 @@ main(int argc, char* argv[]) {
     }
   }
   LOG_VERBOSE("Finished Importing Draft Applications");
+  LOG("Importing AppLoad External Applications");
+  QList<QString> apploadPaths = {"/home/root/xovi/exthome/appload"};
+  for (auto apploadPath : apploadPaths) {
+    QDir apploadDir(apploadPath);
+    if (!apploadDir.exists()) {
+      LOG_VERBOSE("AppLoad directory not found: " << apploadPath);
+      continue;
+    }
+    for (auto appDirInfo : apploadDir.entryInfoList(
+           QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name
+         )) {
+      auto appDir = appDirInfo.absoluteFilePath();
+      auto manifestPath = appDir + "/external.manifest.json";
+      if (!QFile::exists(manifestPath)) {
+        if (QFile::exists(appDir + "/manifest.json")) {
+          LOG_VERBOSE(
+            "Skipping QML AppLoad app (needs AppLoad runtime): "
+            << appDirInfo.fileName()
+          );
+        }
+        continue;
+      }
+      LOG_VERBOSE("Processing " << manifestPath);
+      QFile manifestFile(manifestPath);
+      if (!manifestFile.open(QIODevice::ReadOnly)) {
+        LOG("Failed to open manifest: " << manifestPath);
+        continue;
+      }
+      auto variant = Oxide::JSON::fromJson(&manifestFile);
+      manifestFile.close();
+      auto manifest = variant.toMap();
+      auto displayName = manifest["name"].toString();
+      auto application = manifest["application"].toString();
+      if (displayName.isEmpty() || application.isEmpty()) {
+        LOG("Skipping " << manifestPath << ": missing name or application");
+        continue;
+      }
+      QFileInfo appFileInfo(application);
+      if (appFileInfo.isRelative()) {
+        application = appDir + "/" + application;
+      }
+      QVariantMap properties;
+      properties.insert("name", displayName);
+      properties.insert("displayName", displayName);
+      properties.insert("workingDirectory", appDir);
+      properties.insert("flags", QStringList() << "nopreload");
+      auto iconPath = appDir + "/icon.png";
+      if (QFile::exists(iconPath)) {
+        properties.insert("icon", iconPath);
+      }
+      QVariantMap env;
+      auto args = manifest.value("args");
+      properties.insert("bin", "/home/root/.vellum/share/oxide/libexec/runner");
+      env.insert("EXECUTABLE", application);
+      if (
+        args.isValid() && args.canConvert<QVariantList>() &&
+        !args.toList().isEmpty()
+      ) {
+        QStringList quotedArgs;
+        for (auto arg : args.toList()) {
+          auto a = arg.toString();
+          a.replace("\\", "\\\\");
+          a.replace("\"", "\\\"");
+          a.replace("`", "\\`");
+          a.replace("$", "\\$");
+          quotedArgs << "\"" + a + "\"";
+        }
+        env.insert("ARGUMENTS", quotedArgs.join(" "));
+      }
+      auto environment = manifest.value("environment");
+      if (environment.isValid() && environment.canConvert<QVariantMap>()) {
+        auto environmentMap = environment.toMap();
+        for (auto key : environmentMap.keys()) {
+          auto value = environmentMap[key].toString();
+          if (key == "LD_PRELOAD") {
+            QStringList entries = value.split(":", Qt::SkipEmptyParts);
+            QStringList kept;
+            for (auto entry : entries) {
+              auto filename = QFileInfo(entry).fileName();
+              if (filename == "qtfb-shim-32bit.so") {
+                env.insert("OXIDE_PRELOAD_FORCE_32BIT_FSCREENINFO", "1");
+                continue;
+              }
+              if (filename != "qtfb-shim.so") {
+                kept << entry;
+              }
+            }
+            if (!kept.isEmpty()) {
+              env.insert("LD_PRELOAD", kept.join(":"));
+            }
+            continue;
+          }
+          if (key == "QTFB_SHIM_MODEL") {
+            if (value == "1" || value == "RM1") {
+              env.insert("OXIDE_PRELOAD_FORCE_RM1", "1");
+              continue;
+            } else if (value == "RM2") {
+              env.insert("OXIDE_PRELOAD_FORCE_RM2_NAME", "1");
+              continue;
+            }
+          }
+          if (key == "QTFB_SHIM_INPUT" && value == "0") {
+            env.insert("OXIDE_PRELOAD_EXPOSE_INPUT", "1");
+            continue;
+          }
+          if (key == "QTFB_SHIM_FB" && value == "0") {
+            env.insert("OXIDE_PRELOAD_EXPOSE_FB", "1");
+            continue;
+          }
+          if (key == "QTFB_SHIM_MODE" && value.toLower() == "rgb565") {
+            env.insert("OXIDE_PRELOAD_FORCE_RGB16", "1");
+            continue;
+          }
+          if (key == "QTFB_SHIM_INPUT_MODE" && value == "RM1") {
+            env.insert("OXIDE_PRELOAD_FORCE_RM1_INPUT", "1");
+            continue;
+          }
+          if (key == "QTFB_SHIM_INITIAL_DISPLAY_MODE") {
+            env.insert("OXIDE_PRELOAD_FORCE_WAVEFORM", value);
+            continue;
+          }
+          if (key.startsWith("QTFB_")) {
+            LOG_VERBOSE(
+              "Unhandled AppLoad environment variable: " << key << "=" << value
+            );
+            continue;
+          }
+          env.insert(key, value);
+        }
+      }
+      if (!env.isEmpty()) {
+        properties.insert("environment", env);
+      }
+      auto registrationPath =
+        QString(OXIDE_APPLICATION_REGISTRATIONS_DIRECTORY) + "/" + displayName +
+        ".oxide";
+      if (QFile::exists(registrationPath)) {
+        LOG_VERBOSE("Already registered: " << displayName);
+        continue;
+      }
+      LOG_VERBOSE("Not found, creating...");
+      QFile registrationFile(registrationPath);
+      if (!registrationFile.open(QIODevice::WriteOnly)) {
+        LOG("Failed to create registration: " << registrationPath);
+        continue;
+      }
+      registrationFile.write(
+        QJsonDocument(QJsonObject::fromVariantMap(properties)).toJson()
+      );
+      LOG_VERBOSE("Imported AppLoad app: " << displayName);
+    }
+  }
+  LOG_VERBOSE("Finished Importing AppLoad External Applications");
   apps.reload().waitForFinished();
   return qExit(EXIT_SUCCESS);
 }

--- a/shared/libblight_client/state.cpp
+++ b/shared/libblight_client/state.cpp
@@ -170,7 +170,7 @@ namespace Client {
   }
   bool isFakeRM2FB() {
     if (Client::deviceType != Client::DeviceType::RM1) {
-      return false;
+      return true;
     }
     static bool enabled = getenv("OXIDE_PRELOAD_NO_FAKE_RM2FB") == nullptr;
     return enabled;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for importing external app launch definitions during cache refresh, including metadata, icons, command arguments, and environment configuration.
  * Installed a new runtime launcher used to start packaged apps via the system service.

* **Bug Fixes**
  * Corrected behavior for non-RM1 devices in the client’s RM2FB detection logic to improve compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->