### PR TITLE
Allow marking applications as forking, so they will always launch a new instance from the launcher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,12 @@ build: $(OBJ)
 .PHONY: package
 package: package-armv7 package-aarch64
 
+.PHONY: build-armv7
+build-armv7: build-rm1
+
+.PHONY: build-aarch64
+build-aarch64: build-rm1
+
 .PHONY: package-armv7
 package-armv7: $(DIST) $(BUILD)/package/oxide.tar.gz $(BUILD)/package/VELBUILD
 	CARCH=armv7 vbuild -C $(BUILD)/package
@@ -57,6 +63,23 @@ package-aarch64: $(DIST) $(BUILD)/package/oxide.tar.gz $(BUILD)/package/VELBUILD
 	CARCH=aarch64 vbuild -C $(BUILD)/package
 	mkdir -p $(DIST)/aarch64
 	cp -a $(BUILD)/package/dist/aarch64/. $(DIST)/aarch64
+
+.PHONY: deploy-armv7
+deploy-armv7: package-armv7
+	rsync -aP release/armv7/*.apk remarkable:/home/root/packages
+
+.PHONY: deploy-aarch64
+deploy-aarch64: package-aarch64
+	rsync -aP release/aarch64/*.apk remarkable:/home/root/packages
+
+
+.PHONY: install-armv7
+install-armv7: deploy-armv7
+	ssh remarkable bash -ec 'vellum add packages/*.apk'
+
+.PHONY: install-aarch64
+install-aarch64: deploy-aarch64
+	ssh remarkable bash -ec 'vellum add packages/*.apk'
 
 .PHONY: build-rm1
 build-rm1: clean-base $(DIST)

--- a/Makefile
+++ b/Makefile
@@ -75,11 +75,11 @@ deploy-aarch64: package-aarch64
 
 .PHONY: install-armv7
 install-armv7: deploy-armv7
-	ssh remarkable bash -ec 'vellum add packages/*.apk'
+	echo "vellum add packages/*.apk" | ssh remarkable bash -le
 
 .PHONY: install-aarch64
 install-aarch64: deploy-aarch64
-	ssh remarkable bash -ec 'vellum add packages/*.apk'
+	echo "vellum add packages/*.apk" | ssh remarkable bash -le
 
 .PHONY: build-rm1
 build-rm1: clean-base $(DIST)

--- a/applications/launcher/appitem.cpp
+++ b/applications/launcher/appitem.cpp
@@ -6,6 +6,7 @@
 #include <unistd.h>
 
 #include <QDebug>
+#include <QUuid>
 #include <fstream>
 #include <iostream>
 
@@ -23,13 +24,53 @@ AppItem::execute() {
     O_WARNING("Application instance is not valid");
     return;
   }
-  qDebug() << "Running application " << app->path();
-  try {
+  if (!app->forking()) {
+    qDebug() << "Running application " << app->path();
     app->launch().waitForFinished();
-  } catch (const std::exception& e) {
-    qDebug() << "Failed to launch" << property("name").toString() << e.what();
+    return;
   }
-  qDebug() << "Waiting for application to exit...";
+  qDebug() << "Forking new instance of" << property("name").toString();
+  auto controller = reinterpret_cast<Controller*>(parent());
+  auto apps = controller->getAppsApi();
+  auto bus = QDBusConnection::systemBus();
+  QVariantMap properties;
+  properties["name"] = QUuid::createUuid().toString();
+  properties["bin"] = app->bin();
+  properties["displayName"] = app->displayName();
+  properties["description"] = app->description();
+  properties["type"] = (int)app->type();
+  properties["icon"] = app->icon();
+  properties["workingDirectory"] = app->workingDirectory();
+  properties["user"] = app->user();
+  properties["group"] = app->group();
+  properties["environment"] = app->environment();
+  properties["permissions"] = app->permissions();
+  properties["onPause"] = app->onPause();
+  properties["onResume"] = app->onResume();
+  properties["onStop"] = app->onStop();
+  QStringList cloneFlags = app->flags();
+  if (!cloneFlags.contains("transient")) {
+    cloneFlags.prepend("transient");
+  }
+  cloneFlags.removeAll("forking");
+  properties["flags"] = cloneFlags;
+  QDBusObjectPath path = apps->registerApplication(properties);
+  if (path.path() == "/") {
+    O_WARNING(
+      "Failed to register transient instance of " << property("name").toString()
+    );
+    auto notifications = controller->getNotificationApi();
+    notifications->add(
+      QUuid::createUuid().toString(),
+      "oxide",
+      QStringLiteral("Failed to launch %1")
+        .arg(property("displayName").toString()),
+      ""
+    );
+    return;
+  }
+  Application instance(OXIDE_SERVICE, path.path(), bus);
+  instance.launch().waitForFinished();
 }
 void
 AppItem::stop() {

--- a/applications/launcher/appitem.cpp
+++ b/applications/launcher/appitem.cpp
@@ -45,6 +45,7 @@ AppItem::execute() {
   properties["group"] = app->group();
   properties["environment"] = app->environment();
   properties["permissions"] = app->permissions();
+  properties["directories"] = app->directories();
   properties["onPause"] = app->onPause();
   properties["onResume"] = app->onResume();
   properties["onStop"] = app->onStop();

--- a/applications/launcher/controller.h
+++ b/applications/launcher/controller.h
@@ -551,6 +551,7 @@ public:
     connect(wifiApi, &Wifi::networkRemoved, this, &Controller::networkRemoved);
   }
   Apps* getAppsApi() { return appsApi; }
+  Notifications* getNotificationApi() { return notificationApi; }
 signals:
   void reload();
   void automaticSleepChanged(bool);

--- a/applications/system-service/application.cpp
+++ b/applications/system-service/application.cpp
@@ -616,6 +616,11 @@ Application::group() {
   return value("group", getgid()).toString();
 }
 
+QStringList
+Application::directories() {
+  return value("directories", QStringList()).toStringList();
+}
+
 const QVariantMap&
 Application::getConfig() {
   return m_config;

--- a/applications/system-service/application.cpp
+++ b/applications/system-service/application.cpp
@@ -1107,6 +1107,11 @@ Application::transient() {
 }
 
 bool
+Application::forking() {
+  return flags().contains("forking");
+}
+
+bool
 Application::hidden() {
   return flags().contains("hidden");
 }

--- a/applications/system-service/application.h
+++ b/applications/system-service/application.h
@@ -98,6 +98,7 @@ class Application : public QObject {
   )
   Q_PROPERTY(QString user READ user)
   Q_PROPERTY(QString group READ group)
+  Q_PROPERTY(QStringList directories READ directories)
 
 public:
   Application(QDBusObjectPath path, QObject* parent)
@@ -155,6 +156,7 @@ public:
   void setWorkingDirectory(const QString& workingDirectory);
   QString user();
   QString group();
+  QStringList directories();
 
   const QVariantMap& getConfig();
   void setConfig(const QVariantMap& config);

--- a/applications/system-service/application.h
+++ b/applications/system-service/application.h
@@ -88,6 +88,8 @@ class Application : public QObject {
   Q_PROPERTY(bool systemApp READ systemApp)
   Q_PROPERTY(bool hidden READ hidden)
   Q_PROPERTY(bool transient READ transient)
+  Q_PROPERTY(bool forking READ forking)
+  Q_PROPERTY(QStringList flags READ flags)
   Q_PROPERTY(QString icon READ icon WRITE setIcon NOTIFY iconChanged)
   Q_PROPERTY(QVariantMap environment READ environment NOTIFY environmentChanged)
   Q_PROPERTY(
@@ -140,6 +142,7 @@ public:
   void setAutoStart(bool autoStart);
   bool systemApp();
   bool transient();
+  bool forking();
   bool hidden();
   int type();
   int state();

--- a/interfaces/application.xml
+++ b/interfaces/application.xml
@@ -25,6 +25,7 @@
     <property name="workingDirectory" type="s" access="readwrite"/>
     <property name="user" type="s" access="read"/>
     <property name="group" type="s" access="read"/>
+    <property name="directories" type="as" access="read"/>
     <signal name="launched">
     </signal>
     <signal name="paused">

--- a/interfaces/application.xml
+++ b/interfaces/application.xml
@@ -16,6 +16,8 @@
     <property name="systemApp" type="b" access="read"/>
     <property name="hidden" type="b" access="read"/>
     <property name="transient" type="b" access="read"/>
+    <property name="forking" type="b" access="read"/>
+    <property name="flags" type="as" access="read"/>
     <property name="icon" type="s" access="readwrite"/>
     <property name="environment" type="a{sv}" access="read">
       <annotation name="org.qtproject.QtDBus.QtTypeName" value="QVariantMap"/>

--- a/shared/liboxide/applications.cpp
+++ b/shared/liboxide/applications.cpp
@@ -17,6 +17,7 @@ const QList<QString> SystemFlags{
 const QList<QString> Flags{
   "autoStart",
   "hidden",
+  "forking",
   "noannounce",
   "nosavescreen",
   "system",

--- a/web/src/documentation/03_application_registration_format.rst
+++ b/web/src/documentation/03_application_registration_format.rst
@@ -64,6 +64,7 @@ An array of flags for the application.
 - ``"nopreload.sysfs"``: Do not automatically add ``libsysfs_preload.so`` to ``LD_PRELOAD`` when running this application.
 - ``"exclusive"``: Application is to be run in exclusive mode. This means that the compositor will not be sending input to the application, or handling displaying anything to the screen while this application is in the foreground.
 - ``"noannounce"``: Do not announce when this application is being started
+- ``"forking"``: Allow this application to be launched multiple times. Each launch creates a new independent instance. The task switcher will show all running instances.
 
 displayName
 -----------

--- a/web/src/documentation/03_application_registration_format.rst
+++ b/web/src/documentation/03_application_registration_format.rst
@@ -50,6 +50,8 @@ The type of application this is.
 - ``"foreground"``: This application runs in the foreground and must be paused when it's not the active application.
 - ``"backgroundable"``: This application runs in both the foreground and the background and supports being notified with ``SIGUSR1`` and ``SIGUSR2`` when being swapped between the two states by the user.
 
+.. _registration-flags:
+
 flags
 -----
 Optional string array
@@ -64,7 +66,7 @@ An array of flags for the application.
 - ``"nopreload.sysfs"``: Do not automatically add ``libsysfs_preload.so`` to ``LD_PRELOAD`` when running this application.
 - ``"exclusive"``: Application is to be run in exclusive mode. This means that the compositor will not be sending input to the application, or handling displaying anything to the screen while this application is in the foreground.
 - ``"noannounce"``: Do not announce when this application is being started
-- ``"forking"``: Allow this application to be launched multiple times. Each launch creates a new independent instance. The task switcher will show all running instances.
+- ``"forking"``: Allow this application to be launched multiple times from the launcher. Each launch from the launcher creates a fresh independent instance. The task switcher will show all running instances.
 
 displayName
 -----------

--- a/web/src/documentation/api/02_apps.rst
+++ b/web/src/documentation/api/02_apps.rst
@@ -240,6 +240,29 @@ Application Object
 |                      |                             | from the user on any |
 |                      |                             | UI.                  |
 +----------------------+-----------------------------+----------------------+
+| transient            | ``BOOLEAN`` property        | If this application  |
+|                      | (read)                      | is a transient       |
+|                      |                             | instance created at  |
+|                      |                             | runtime rather than  |
+|                      |                             | from a file          |
+|                      |                             | registration.        |
++----------------------+-----------------------------+----------------------+
+| forking              | ``BOOLEAN`` property        | If this application  |
+|                      | (read)                      | can be launched      |
+|                      |                             | multiple times from  |
+|                      |                             | the launcher as      |
+|                      |                             | independent          |
+|                      |                             | transient instances. |
++----------------------+-----------------------------+----------------------+
+| flags                | ``ARRAY STRING`` property   | A list of flags for  |
+|                      | (read)                      | this application.    |
+|                      |                             | See the              |
+|                      |                             | :ref:`registration   |
+|                      |                             | format               |
+|                      |                             | <registration-       |
+|                      |                             | flags>` for          |
+|                      |                             | possible values.     |
++----------------------+-----------------------------+----------------------+
 | icon                 | ``STRING`` property         | Path to the icon     |
 |                      | (read/write)                | used to represent    |
 |                      |                             | this application.    |
@@ -259,6 +282,10 @@ Application Object
 | group                | ``STRING`` property         | Group the            |
 |                      | (read)                      | application will be  |
 |                      |                             | run as.              |
++----------------------+-----------------------------+----------------------+
+| directories          | ``ARRAY STRING`` property   | List of directories  |
+|                      | (read)                      | to mount for the     |
+|                      |                             | application.         |
 +----------------------+-----------------------------+----------------------+
 | launched             | signal                      | Signal sent when the |
 |                      |                             | application starts.  |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for apps marked as launchable as independent instances; they appear separately in the app switcher.
  * Extended application metadata with new read-only properties for launch behavior and mounted directories.
  * Improved handling of transient launching for compatible apps.
* **Bug Fixes**
  * When an app registration/launch fails, the system now shows an on-screen notification.
* **Documentation**
  * Updated the application registration format and API reference to include the new `forking` flag, `flags`, and `directories`.
* **Chores**
  * Added build/deploy/install Makefile targets for additional architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->