### PR TITLE
Allow opening applications with arguments

### DIFF
--- a/applications/gio/launch.h
+++ b/applications/gio/launch.h
@@ -24,7 +24,7 @@ class LaunchCommand : ICommand {
       "DESKTOP-FILE", "Application registration to launch"
     );
     parser->addPositionalArgument(
-      "FILE-ARG", "NOT IMPLEMENTED", "[FILE-ARG...]"
+      "FILE-ARG", "File arguments to pass to the application", "[FILE-ARG...]"
     );
     return EXIT_SUCCESS;
   }
@@ -124,7 +124,7 @@ class LaunchCommand : ICommand {
       return EXIT_FAILURE;
     }
     Application app(OXIDE_SERVICE, qpath.path(), bus);
-    app.launch().waitForFinished();
+    app.launchWithArgs(args.mid(1)).waitForFinished();
     return EXIT_SUCCESS;
   }
 };

--- a/applications/system-service/application.cpp
+++ b/applications/system-service/application.cpp
@@ -25,10 +25,17 @@ Application::launch() {
   if (!hasPermission("apps")) {
     return;
   }
-  launchNoSecurityCheck();
+  launchNoSecurityCheck({});
 }
 void
-Application::launchNoSecurityCheck() {
+Application::launchWithArgs(const QStringList& args) {
+  if (!hasPermission("apps")) {
+    return;
+  }
+  launchNoSecurityCheck(args);
+}
+void
+Application::launchNoSecurityCheck(const QStringList& args) {
   if (m_process->processId()) {
     resumeNoSecurityCheck();
   } else {
@@ -44,7 +51,7 @@ Application::launchNoSecurityCheck() {
       startSpan("starting", "Application is starting");
     }
     Oxide::Sentry::sentry_transaction(
-      "Launch Application", "launch", [this](Oxide::Sentry::Transaction* t) {
+      "Launch Application", "launch", [this, args](Oxide::Sentry::Transaction* t) {
 #ifdef SENTRY
         if (t != nullptr) {
           sentry_transaction_set_tag(
@@ -127,7 +134,7 @@ Application::launchNoSecurityCheck() {
             }
           }
         }
-        m_process->start();
+        m_process->start(bin(), args);
         m_process->waitForStarted();
         if (type() == Background) {
           startSpan("background", "Application is in the background");

--- a/applications/system-service/application.cpp
+++ b/applications/system-service/application.cpp
@@ -51,7 +51,9 @@ Application::launchNoSecurityCheck(const QStringList& args) {
       startSpan("starting", "Application is starting");
     }
     Oxide::Sentry::sentry_transaction(
-      "Launch Application", "launch", [this, args](Oxide::Sentry::Transaction* t) {
+      "Launch Application",
+      "launch",
+      [this, args](Oxide::Sentry::Transaction* t) {
 #ifdef SENTRY
         if (t != nullptr) {
           sentry_transaction_set_tag(
@@ -59,7 +61,7 @@ Application::launchNoSecurityCheck(const QStringList& args) {
           );
         }
 #else
-                Q_UNUSED(t);
+        Q_UNUSED(t);
 #endif
         appsAPI->recordPreviousApplication();
         O_INFO("Launching " << path());

--- a/applications/system-service/application.h
+++ b/applications/system-service/application.h
@@ -114,12 +114,13 @@ public:
   Q_ENUM(ApplicationState)
 
   Q_INVOKABLE void launch();
+  Q_INVOKABLE void launchWithArgs(const QStringList& args);
   Q_INVOKABLE void pause(bool startIfNone = true);
   Q_INVOKABLE void resume();
   Q_INVOKABLE void stop();
   Q_INVOKABLE void unregister();
 
-  void launchNoSecurityCheck();
+  void launchNoSecurityCheck(const QStringList& args = {});
   void resumeNoSecurityCheck();
   void stopNoSecurityCheck();
   void pauseNoSecurityCheck(bool startIfNone = true);

--- a/applications/xdg-open/main.cpp
+++ b/applications/xdg-open/main.cpp
@@ -3,6 +3,7 @@
 #include <sys/stat.h>
 
 #include <QCommandLineParser>
+#include <QUrlQuery>
 #include <string>
 
 using namespace Oxide::Sentry;
@@ -10,7 +11,7 @@ using namespace Oxide::Applications;
 using namespace codes::eeems::oxide1;
 
 int
-launchOxideApp(const QString& name) {
+launchOxideApp(const QString& name, const QStringList& launchArgs = {}) {
   auto bus = QDBusConnection::systemBus();
   General api(OXIDE_SERVICE, OXIDE_SERVICE_PATH, bus);
   QDBusObjectPath path = api.requestAPI("apps");
@@ -25,7 +26,11 @@ launchOxideApp(const QString& name) {
     return EXIT_FAILURE;
   }
   Application app(OXIDE_SERVICE, path.path(), bus);
-  app.launch().waitForFinished();
+  if (launchArgs.isEmpty()) {
+    app.launch().waitForFinished();
+  } else {
+    app.launchWithArgs(launchArgs).waitForFinished();
+  }
   return EXIT_SUCCESS;
 }
 
@@ -73,15 +78,20 @@ main(int argc, char* argv[]) {
     return launchOxideApp(name);
   } else if (url.scheme() == "oxide") {
     if (
-      url.hasFragment() || url.hasQuery() || !url.userInfo().isEmpty() ||
+      url.hasFragment() || !url.userInfo().isEmpty() ||
       !url.authority().isEmpty()
     ) {
-      qDebug() << "Url must bein the format oxide://{appname} :"
+      qDebug() << "Url must be in the format oxide:{appname}[?arg=...] :"
                << path.toStdString().c_str();
       return EXIT_FAILURE;
     }
     auto name = url.path();
-    return launchOxideApp(name);
+    QStringList launchArgs;
+    if (url.hasQuery()) {
+      QUrlQuery query(url);
+      launchArgs = query.allQueryItemValues("arg");
+    }
+    return launchOxideApp(name, launchArgs);
   }
   qDebug() << "Operation not supported:" << path.toStdString().c_str();
   return EXIT_FAILURE;

--- a/interfaces/application.xml
+++ b/interfaces/application.xml
@@ -74,6 +74,9 @@
     </method>
     <method name="launch">
     </method>
+    <method name="launchWithArgs">
+      <arg name="args" type="as" direction="in"/>
+    </method>
     <method name="pause">
       <arg name="startIfNone" type="b" direction="in"/>
     </method>

--- a/web/src/documentation/02_oxide-utils.rst
+++ b/web/src/documentation/02_oxide-utils.rst
@@ -34,10 +34,12 @@ https://man.archlinux.org/man/xdg-desktop-icon.1
 xdg-open
 ========
 
-Opens a file or URL. Supports the following formats:
+https://man.archlinux.org/man/xdg-open.1
 
-- **Local ``.oxide`` files** in the application registrations directory launch the corresponding application.
-- **``oxide:`` URLs** launch an application by name, optionally passing arguments.
+Supports the following formats:
+
+- Local ``.oxide`` files in the application registrations directory launch the corresponding application.
+- ``oxide:`` URLs launch an application by name, optionally passing arguments.
 
 ``oxide:`` URL format:
 
@@ -58,9 +60,6 @@ Examples:
   # Launch editor with multiple files
   xdg-open 'oxide:editor?arg=file1.txt&arg=file2.txt'
 
-See also the upstream man page:
-
-https://man.archlinux.org/man/xdg-open.1
 
 xdg-settings
 ============

--- a/web/src/documentation/02_oxide-utils.rst
+++ b/web/src/documentation/02_oxide-utils.rst
@@ -34,6 +34,32 @@ https://man.archlinux.org/man/xdg-desktop-icon.1
 xdg-open
 ========
 
+Opens a file or URL. Supports the following formats:
+
+- **Local ``.oxide`` files** in the application registrations directory launch the corresponding application.
+- **``oxide:`` URLs** launch an application by name, optionally passing arguments.
+
+``oxide:`` URL format:
+
+.. code:: text
+
+  oxide:{appname}[?arg={value}&arg={value}...]
+
+Examples:
+
+.. code:: shell
+
+  # Launch xochitl
+  xdg-open oxide:xochitl
+
+  # Launch reader with a document
+  xdg-open 'oxide:reader?arg=/home/root/document.pdf'
+
+  # Launch editor with multiple files
+  xdg-open 'oxide:editor?arg=file1.txt&arg=file2.txt'
+
+See also the upstream man page:
+
 https://man.archlinux.org/man/xdg-open.1
 
 xdg-settings

--- a/web/src/documentation/api/02_apps.rst
+++ b/web/src/documentation/api/02_apps.rst
@@ -357,6 +357,13 @@ Application Object
 | launch               | method                      | Launch or resume the |
 |                      |                             | application.         |
 +----------------------+-----------------------------+----------------------+
+| launchWithArgs       | method                      | Launch the          |
+|                      |                             | application with the |
+|                      | - (in) args                 | given arguments. If  |
+|                      |   ``ARRAY STRING``          | the application is   |
+|                      |                             | already running it   |
+|                      |                             | will be resumed.     |
++----------------------+-----------------------------+----------------------+
 | pause                | method                      | Pause the            |
 |                      |                             | application.         |
 |                      |                             | If the application   |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launch apps with command-line arguments from the CLI and `oxide:` launch links (forwarding provided args through to the launched app).
  * Added `launchWithArgs` to the application API/DBus interface for launching with an argument list.
* **Bug Fixes**
  * Improved `oxide:` URL validation and error handling by rejecting unsupported URL components (e.g., fragments and other invalid parts) and forwarding repeated `arg` query values.
* **Documentation**
  * Expanded `xdg-open` docs and API reference with supported input formats and `oxide:{appname}[?arg=…]` examples (including multiple arguments).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->