### PR TITLE
Validate message size is set when type requires it

### DIFF
--- a/shared/libblight_protocol/libblight_protocol.cpp
+++ b/shared/libblight_protocol/libblight_protocol.cpp
@@ -89,6 +89,28 @@ static std::atomic_uint ackid = 0;
 static std::atomic_uint _marker = 0;
 
 using namespace BlightProtocol;
+bool
+is_valid_header(const blight_header_t& header) {
+  if (
+    header.type <= BlightMessageType::Invalid ||
+    header.type >= BlightMessageType::MAX
+  ) {
+    return false;
+  }
+  switch (header.type) {
+    case BlightMessageType::Move:
+    case BlightMessageType::Repaint:
+    case BlightMessageType::Info:
+    case BlightMessageType::Delete:
+    case BlightMessageType::Raise:
+    case BlightMessageType::Lower:
+    case BlightMessageType::Wait:
+      return header.size > 0;
+    default:
+      return true;
+  }
+}
+
 extern "C" {
 int
 blight_bus_connect_system(blight_bus** bus) {
@@ -272,6 +294,15 @@ blight_message_t*
 blight_message_from_data(blight_data_t data) {
   auto message = new blight_message_t;
   message->header = blight_header_from_data(data);
+  if (!is_valid_header(message->header)) {
+    _WARN(
+      "Invalid message type=%d, size=%ld",
+      message->header.type,
+      (long int)message->header.size
+    );
+    delete message;
+    return nullptr;
+  }
   if (message->header.size) {
     message->data = new unsigned char[message->header.size];
     memcpy(message->data, &data[sizeof(message->header)], message->header.size);
@@ -302,12 +333,9 @@ blight_message_from_socket(int fd, blight_message_t** message) {
   };
   memcpy(&m->header, maybe.value(), sizeof(blight_header_t));
   delete[] maybe.value();
-  if (
-    m->header.type == BlightMessageType::Invalid ||
-    m->header.type >= BlightMessageType::MAX
-  ) {
+  if (!is_valid_header(m->header)) {
     _WARN(
-      "Recieved invalid message from socket"
+      "Recieved invalid message from socket "
       "socket=%d, "
       "ackid=%u, "
       "type=%d, "

--- a/tests/libblight_protocol/test.c
+++ b/tests/libblight_protocol/test.c
@@ -100,6 +100,51 @@ test_blight_message_from_data() {
   free(data);
 }
 void
+test_blight_message_from_socket_rejects_zero_data() {
+  int sv[2];
+  assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == 0);
+
+  for (int type = Repaint; type <= Wait; type++) {
+    if (type == Ack || type == Ping || type == List || type == Focus) {
+      continue;
+    }
+
+    blight_header_t hdr;
+    hdr.type = type;
+    hdr.ackid = 1;
+    hdr.size = 0;
+    assert(send(sv[0], &hdr, sizeof(hdr), 0) == sizeof(hdr));
+
+    blight_message_t* msg = NULL;
+    int res = blight_message_from_socket(sv[1], &msg);
+    assert(res < 0);
+    assert(errno == EBADMSG);
+    assert(msg == NULL);
+  }
+
+  close(sv[0]);
+  close(sv[1]);
+}
+void
+test_blight_message_from_data_rejects_zero_data() {
+  for (int type = Repaint; type <= Wait; type++) {
+    if (type == Ack || type == Ping || type == List || type == Focus) {
+      continue;
+    }
+
+    blight_header_t hdr;
+    hdr.type = type;
+    hdr.ackid = 1;
+    hdr.size = 0;
+    blight_data_t buf = malloc(sizeof(hdr));
+    assert(buf != NULL);
+    memcpy(buf, &hdr, sizeof(hdr));
+    blight_message_t* msg = blight_message_from_data(buf);
+    assert(msg == NULL);
+    free(buf);
+  }
+}
+void
 test_blight_bus_connect_system() {
   assert(blight_bus_connect_system(&bus) > 0);
   assert(bus != NULL);
@@ -545,6 +590,8 @@ test_c() {
   gettimeofday(&start, NULL);
   TEST(test_blight_header_from_data, true);
   TEST(test_blight_message_from_data, true);
+  TEST(test_blight_message_from_socket_rejects_zero_data, true);
+  TEST(test_blight_message_from_data_rejects_zero_data, true);
   TEST(test_blight_bus_connect_system, true);
   TEST(test_blight_service_available, bus != NULL);
   int fd = 0;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message validation to reject malformed headers with invalid types or missing required payloads.
  * Parsing now safely rejects invalid messages from both raw data and sockets, returning an error instead of accepting them.
  * Added clearer error handling for bad socket messages, including proper failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->