### PR TITLE
Fix #344

### DIFF
--- a/applications/settings-manager/main.cpp
+++ b/applications/settings-manager/main.cpp
@@ -10,6 +10,17 @@ using namespace codes::eeems::blight1;
 using namespace Oxide::Sentry;
 using namespace Oxide::JSON;
 
+static QVariant
+convertDbusVariant(const QString& typeName, const QVariant& value) {
+  if (typeName == "QDBusObjectPath") {
+    return QVariant::fromValue(QDBusObjectPath(value.toString()));
+  }
+  if (typeName == "QDBusSignature") {
+    return QVariant::fromValue(QDBusSignature(value.toString()));
+  }
+  return value;
+}
+
 int
 qExit(int ret) {
   QTimer::singleShot(0, [ret]() { qApp->exit(ret); });
@@ -351,13 +362,23 @@ main(int argc, char* argv[]) {
     qStdOut << toJson(value).toStdString().c_str() << Qt::endl;
   } else if (action == "set") {
     auto property = args.at(2).toStdString();
-    if (!api->setProperty(property.c_str(), args.at(3).toStdString().c_str())) {
+    QVariant value = args.at(3);
+    if (iapi != nullptr) {
+      auto meta = iapi->metaObject();
+      auto propIndex = meta->indexOfProperty(property.c_str());
+      if (propIndex >= 0) {
+        value = convertDbusVariant(
+          QString(meta->property(propIndex).typeName()), value
+        );
+      }
+    }
+    if (!api->setProperty(property.c_str(), value)) {
       qDebug() << "Failed to set value";
       if (iapi != nullptr) {
         qDebug() << iapi->lastError();
       }
 #ifdef SENTRY
-      sentry_breadcrumb("error", "Failed to get value");
+      sentry_breadcrumb("error", "Failed to set value");
 #endif
       return qExit(EXIT_FAILURE);
     }
@@ -412,12 +433,8 @@ main(int argc, char* argv[]) {
 #endif
           return qExit(EXIT_FAILURE);
         }
-        QVariant variant = fromJson(value.toUtf8());
-        if (typeName == "QDBusObjectPath") {
-          variant = QVariant::fromValue(QDBusObjectPath(variant.toString()));
-        } else if (typeName == "QDBusSignature") {
-          variant = QVariant::fromValue(QDBusSignature(variant.toString()));
-        }
+        QVariant variant =
+          convertDbusVariant(typeName, fromJson(value.toUtf8()));
         if (!variant.canConvert(type)) {
           qDebug() << "Unable to convert to type" << typeName;
           qDebug() << "Value" << variant;

--- a/applications/xdg-settings/main.cpp
+++ b/applications/xdg-settings/main.cpp
@@ -194,7 +194,7 @@ check_command(QCommandLineParser& parser) {
     qDebug() << "xdg-settings: Failed to get property";
     parser.showHelp(EXIT_FAILURE);
   }
-  qStdOut() << (args.last() == value ? "yes" : "no") << Qt::endl;
+  qStdOut() << (args.last() == value.toString() ? "yes" : "no") << Qt::endl;
   return EXIT_SUCCESS;
 }
 
@@ -220,15 +220,26 @@ set_command(QCommandLineParser& parser) {
     qDebug() << "xdg-settings: Unknown property" << name;
     parser.showHelp(EXIT_FAILURE);
   }
-  QVariant value = obj->property(name.toStdString().c_str());
-  if (!value.isValid()) {
+  QVariant current = obj->property(name.toStdString().c_str());
+  if (!current.isValid()) {
     qDebug() << "xdg-settings: Failed to get property";
     parser.showHelp(EXIT_FAILURE);
   }
-  if (obj->setProperty(name.toStdString().c_str(), args.last())) {
+  QVariant value = args.last();
+  QDBusAbstractInterface* api = qobject_cast<QDBusAbstractInterface*>(obj);
+  if (api != nullptr) {
+    auto meta = api->metaObject();
+    auto propIndex = meta->indexOfProperty(name.toStdString().c_str());
+    if (propIndex >= 0) {
+      auto typeName = QString(meta->property(propIndex).typeName());
+      if (typeName == "QDBusObjectPath") {
+        value = QVariant::fromValue(QDBusObjectPath(value.toString()));
+      }
+    }
+  }
+  if (obj->setProperty(name.toStdString().c_str(), value)) {
     return EXIT_SUCCESS;
   }
-  QDBusAbstractInterface* api = qobject_cast<QDBusAbstractInterface*>(obj);
   if (api == nullptr) {
     qDebug() << "xdg-settings: failed to set property";
   } else {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of D-Bus property values so object paths and signatures are set and passed correctly.
  * Fixed comparisons in command checks to use the current value as text, reducing mismatches for yes/no-style inputs.
  * Made setting properties more reliable by converting values to the expected type before applying changes, with clearer failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->