### PR TITLE
Fix thread names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,21 +37,22 @@ clean-base:
 clean: clean-base
 	rm -rf $(BUILD)
 
+.NOTPARALLEL: release
 .PHONY: release
 release: clean-base build $(DIST)
 ifneq ($(filter sentry,$(FEATURES)),)
 	# Force sentry makefile to regenerate so that install targets get when being build in toltecmk
-	cd $(BUILD)/$(BUILDNAME)/shared/sentry && make qmake $(DEFINES)
+	cd $(BUILD)/$(BUILDNAME)/shared/sentry && make qmake
 else
 	# Force cpptrace/sentry makefile to regenerate so that install targets get when being built in vbuild
-	cd $(BUILD)/$(BUILDNAME)/shared/cpptrace && make qmake $(DEFINES)
+	cd $(BUILD)/$(BUILDNAME)/shared/cpptrace && make qmake
 endif
 	# Force liboxide makefile to regenerate so that install targets get when being built in vbuild
-	cd $(BUILD)/$(BUILDNAME)/shared/liboxide && make qmake $(DEFINES)
+	cd $(BUILD)/$(BUILDNAME)/shared/liboxide && make qmake
 	# Force libblight makefile to regenerate so that install targets get when being built in vbuild
-	cd $(BUILD)/$(BUILDNAME)/shared/libblight && make qmake $(DEFINES)
+	cd $(BUILD)/$(BUILDNAME)/shared/libblight && make qmake
 	# Force libblight_protocol makefile to regenerate so that install targets get when being built in vbuild
-	cd $(BUILD)/$(BUILDNAME)/shared/libblight_protocol && make qmake $(DEFINES)
+	cd $(BUILD)/$(BUILDNAME)/shared/libblight_protocol && make qmake
 	INSTALL_ROOT=$(DIST) $(MAKE) --output-sync=target -C $(BUILD)/$(BUILDNAME) install
 
 .PHONY: build

--- a/applications/display-server/dbusinterface.cpp
+++ b/applications/display-server/dbusinterface.cpp
@@ -17,6 +17,7 @@
 #include <QFileInfo>
 #include <QQmlComponent>
 #include <cstring>
+#include <mutex>
 
 #include "connection.h"
 #include "evdevhandler.h"
@@ -83,12 +84,13 @@ DbusInterface::DbusInterface(QObject* parent)
 DbusInterface*
 DbusInterface::singleton() {
   static DbusInterface* instance = nullptr;
-  if (instance == nullptr) {
+  static std::once_flag initFlag;
+  std::call_once(initFlag, []() {
     instance = Oxide::dispatchToMainThread<DbusInterface*>([] {
       O_DEBUG("Initializing DBus interface");
       return new DbusInterface(qApp);
     });
-  }
+  });
   return instance;
 }
 

--- a/applications/display-server/guithread.cpp
+++ b/applications/display-server/guithread.cpp
@@ -7,7 +7,9 @@
 #include <liboxide/devicesettings.h>
 #include <liboxide/oxideqml.h>
 #include <liboxide/threading.h>
+#include <mutex>
 #include <mxcfb.h>
+#include <pthread.h>
 #include <sys/mman.h>
 
 #include <QAbstractEventDispatcher>
@@ -50,6 +52,8 @@ GUIThread::run() {
     }
   });
   clearFrameBuffer();
+  setObjectName("GUIThread");
+  pthread_setname_np(pthread_self(), "GUIThread");
   auto res = exec();
   O_DEBUG("Thread stopped with exit code:" << res);
 }
@@ -57,10 +61,13 @@ GUIThread::run() {
 GUIThread*
 GUIThread::singleton() {
   static GUIThread* instance = nullptr;
-  if (instance == nullptr) {
+  static std::once_flag initFlag;
+  std::call_once(initFlag, []() {
     instance = new GUIThread(getFrameBuffer()->rect());
+    // Handle renaming libqsgepaper worker threads that will start here
+    instance->setObjectName("update-worker");
     Oxide::startThreadWithPriority(instance, QThread::TimeCriticalPriority);
-  }
+  });
   return instance;
 }
 

--- a/applications/system-service/dbusservice.cpp
+++ b/applications/system-service/dbusservice.cpp
@@ -1,5 +1,6 @@
 #include "dbusservice.h"
 
+#include <mutex>
 #include <systemd/sd-daemon.h>
 
 #include "appsapi.h"
@@ -14,7 +15,8 @@ using namespace std::chrono;
 DBusService*
 DBusService::singleton() {
   static DBusService* instance;
-  if (instance == nullptr) {
+  static std::once_flag initFlag;
+  std::call_once(initFlag, []() {
     qRegisterMetaType<QMap<QString, QDBusObjectPath>>();
     O_DEBUG("Creating DBusService instance");
     instance = new DBusService(qApp);
@@ -59,7 +61,7 @@ DBusService::singleton() {
       SLOT(serviceOwnerChanged(QString, QString, QString))
     );
     O_DEBUG("Registered");
-  }
+  });
   return instance;
 }
 

--- a/applications/system-service/eventlistener.cpp
+++ b/applications/system-service/eventlistener.cpp
@@ -1,14 +1,16 @@
 #include "eventlistener.h"
 
 #include <QMutexLocker>
+#include <mutex>
 
 EventListener*
 EventListener::instance() {
   static EventListener* instance = nullptr;
-  if (instance == nullptr) {
+  static std::once_flag initFlag;
+  std::call_once(initFlag, []() {
     instance = new EventListener();
     qApp->installEventFilter(static_cast<QObject*>(instance));
-  }
+  });
   return instance;
 }
 

--- a/shared/cpptrace/cpptrace.pro
+++ b/shared/cpptrace/cpptrace.pro
@@ -1,44 +1,41 @@
 TEMPLATE = aux
+!contains(DEFINES, SENTRY) {
+    include(../../qmake/common.pri)
 
-include(../../qmake/common.pri)
+    PRE_TARGETDEPS += $$OUT_PWD/src/Makefile
+    cpptrace_makefile.target = $$OUT_PWD/src/Makefile
+    cpptrace_makefile.commands = \
+        cmake -B $$OUT_PWD/src \
+            -S $$PWD/src \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCPPTRACE_UNWIND_WITH_EXECINFO=on \
+            -DCPPTRACE_GET_SYMBOLS_WITH_LIBDL=on \
+            -DCPPTRACE_BUILD_SHARED=on
+    QMAKE_EXTRA_TARGETS += cpptrace_makefile
 
-contains(DEFINES, SENTRY) {
-    error("Not configured to build cpptrace")
+    PRE_TARGETDEPS += $$OUT_PWD/src/libcpptrace.so
+    cpptrace_build.target = $$OUT_PWD/src/libcpptrace.so
+    cpptrace_build.depends = cpptrace_makefile
+    cpptrace_build.commands = \
+        cmake --build $$OUT_PWD/src --parallel
+    QMAKE_EXTRA_TARGETS += cpptrace_build
+
+    PRE_TARGETDEPS += $$OUT_PWD/lib/libcpptrace.so
+    cpptrace_install.target = $$OUT_PWD/lib/libcpptrace.so
+    cpptrace_install.depends = cpptrace_build
+    cpptrace_install.commands = \
+        cmake --install $$OUT_PWD/src \
+            --prefix $$OUT_PWD \
+            --config RelWithDebInfo
+    QMAKE_EXTRA_TARGETS += cpptrace_install
+
+    QMAKE_CLEAN += -r $$OUT_PWD/src/
+
+    target.files = \
+        $$OUT_PWD/lib/libcpptrace.so \
+        $$OUT_PWD/lib/libcpptrace.so.*
+    target.depends = cpptrace_install
+    target.path = $$LIB_INSTALL_PATH/
+    INSTALLS += target
 }
-
-PRE_TARGETDEPS += $$OUT_PWD/src/Makefile
-cpptrace_makefile.target = $$OUT_PWD/src/Makefile
-cpptrace_makefile.commands = \
-    cmake -B $$OUT_PWD/src \
-        -S $$PWD/src \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-        -DCPPTRACE_UNWIND_WITH_EXECINFO=on \
-        -DCPPTRACE_GET_SYMBOLS_WITH_LIBDL=on \
-        -DCPPTRACE_BUILD_SHARED=on
-QMAKE_EXTRA_TARGETS += cpptrace_makefile
-
-PRE_TARGETDEPS += $$OUT_PWD/src/libcpptrace.so
-cpptrace_build.target = $$OUT_PWD/src/libcpptrace.so
-cpptrace_build.depends = cpptrace_makefile
-cpptrace_build.commands = \
-    cmake --build $$OUT_PWD/src --parallel
-QMAKE_EXTRA_TARGETS += cpptrace_build
-
-PRE_TARGETDEPS += $$OUT_PWD/lib/libcpptrace.so
-cpptrace_install.target = $$OUT_PWD/lib/libcpptrace.so
-cpptrace_install.depends = cpptrace_build
-cpptrace_install.commands = \
-    cmake --install $$OUT_PWD/src \
-        --prefix $$OUT_PWD \
-        --config RelWithDebInfo
-QMAKE_EXTRA_TARGETS += cpptrace_install
-
-QMAKE_CLEAN += -r $$OUT_PWD/src/
-
-target.files = \
-    $$OUT_PWD/lib/libcpptrace.so \
-    $$OUT_PWD/lib/libcpptrace.so.*
-target.depends = cpptrace_install
-target.path = $$LIB_INSTALL_PATH/
-INSTALLS += target

--- a/shared/cpptrace/cpptrace.pro
+++ b/shared/cpptrace/cpptrace.pro
@@ -7,7 +7,6 @@ TEMPLATE = aux
     cpptrace_makefile.commands = \
         cmake -B $$OUT_PWD/src \
             -S $$PWD/src \
-            -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCPPTRACE_UNWIND_WITH_EXECINFO=on \
             -DCPPTRACE_GET_SYMBOLS_WITH_LIBDL=on \

--- a/shared/liboxide/devicesettings.cpp
+++ b/shared/liboxide/devicesettings.cpp
@@ -1,5 +1,6 @@
 #include "devicesettings.h"
 
+#include <mutex>
 #include <private/qguiapplication_p.h>
 #include <private/qinputdevicemanager_p.h>
 

--- a/shared/liboxide/udev.cpp
+++ b/shared/liboxide/udev.cpp
@@ -5,6 +5,7 @@
 #include <QThread>
 #include <QtConcurrent/QtConcurrentRun>
 #include <cerrno>
+#include <mutex>
 
 #include "debug.h"
 #include "liboxide.h"

--- a/shared/lockscreen_hook/receiver.cpp
+++ b/shared/lockscreen_hook/receiver.cpp
@@ -5,13 +5,16 @@
 #include <QFileInfo>
 #include <QProcess>
 #include <QVariant>
+#include <mutex>
 #include <unistd.h>
 
 Q_LOGGING_CATEGORY(loggingCategory, "lockscreen_hook");
 
 LockscreenHookReceiver*
 LockscreenHookReceiver::singleton() {
-  static LockscreenHookReceiver* instance = new LockscreenHookReceiver();
+  static LockscreenHookReceiver* instance = nullptr;
+  static std::once_flag initFlag;
+  std::call_once(initFlag, []() { instance = new LockscreenHookReceiver(); });
   return instance;
 }
 

--- a/shared/qpa/oxideintegration.cpp
+++ b/shared/qpa/oxideintegration.cpp
@@ -17,6 +17,7 @@
 #include <QProcess>
 #include <QQuickWindow>
 #include <cstring>
+#include <mutex>
 
 #include "oxidebackingstore.h"
 #include "oxideeventfilter.h"

--- a/shared/sentry/sentry.pro
+++ b/shared/sentry/sentry.pro
@@ -1,44 +1,41 @@
 TEMPLATE = aux
+contains(DEFINES, SENTRY) {
+    include(../../qmake/common.pri)
 
-include(../../qmake/common.pri)
+    PRE_TARGETDEPS += $$OUT_PWD/src/Makefile
+    sentry_makefile.target = $$OUT_PWD/src/Makefile
+    sentry_makefile.commands = \
+        cmake -B $$OUT_PWD/src \
+            -S $$PWD/src \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DSENTRY_BUILD_SHARED_LIBS=ON \
+            -DSENTRY_INTEGRATION_QT=ON \
+            -DSENTRY_TRANSPORT=curl \
+            -DSENTRY_BACKEND=breakpad \
+            -DSENTRY_BREAKPAD_SYSTEM=OFF \
+            -DSENTRY_SDK_NAME=sentry.native
+    QMAKE_EXTRA_TARGETS += sentry_makefile
 
-!contains(DEFINES, SENTRY) {
-    error("Not configured to build sentry")
+    PRE_TARGETDEPS += $$OUT_PWD/src/libsentry.so
+    sentry_build.target = $$OUT_PWD/src/libsentry.so
+    sentry_build.depends = sentry_makefile
+    sentry_build.commands = \
+        cmake --build $$OUT_PWD/src --parallel
+    QMAKE_EXTRA_TARGETS += sentry_build
+
+    PRE_TARGETDEPS += $$OUT_PWD/lib/libsentry.so
+    sentry_install.target = $$OUT_PWD/lib/libsentry.so
+    sentry_install.depends = sentry_build
+    sentry_install.commands = \
+        cmake --install $$OUT_PWD/src \
+            --prefix $$OUT_PWD \
+            --config RelWithDebInfo
+    QMAKE_EXTRA_TARGETS += sentry_install
+
+    QMAKE_CLEAN += -r $$OUT_PWD/src/
+
+    target.files = $$OUT_PWD/lib/libsentry.so
+    target.depends = sentry_install
+    target.path = $$LIB_INSTALL_PATH/
+    INSTALLS += target
 }
-
-PRE_TARGETDEPS += $$OUT_PWD/src/Makefile
-sentry_makefile.target = $$OUT_PWD/src/Makefile
-sentry_makefile.commands = \
-    cmake -B $$OUT_PWD/src \
-        -S $$PWD/src \
-        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-        -DSENTRY_BUILD_SHARED_LIBS=ON \
-        -DSENTRY_INTEGRATION_QT=ON \
-        -DSENTRY_TRANSPORT=curl \
-        -DSENTRY_BACKEND=breakpad \
-        -DSENTRY_BREAKPAD_SYSTEM=OFF \
-        -DSENTRY_SDK_NAME=sentry.native
-QMAKE_EXTRA_TARGETS += sentry_makefile
-
-PRE_TARGETDEPS += $$OUT_PWD/src/libsentry.so
-sentry_build.target = $$OUT_PWD/src/libsentry.so
-sentry_build.depends = sentry_makefile
-sentry_build.commands = \
-    cmake --build $$OUT_PWD/src --parallel
-QMAKE_EXTRA_TARGETS += sentry_build
-
-PRE_TARGETDEPS += $$OUT_PWD/lib/libsentry.so
-sentry_install.target = $$OUT_PWD/lib/libsentry.so
-sentry_install.depends = sentry_build
-sentry_install.commands = \
-    cmake --install $$OUT_PWD/src \
-        --prefix $$OUT_PWD \
-        --config RelWithDebInfo
-QMAKE_EXTRA_TARGETS += sentry_install
-
-QMAKE_CLEAN += -r $$OUT_PWD/src/
-
-target.files = $$OUT_PWD/lib/libsentry.so
-target.depends = sentry_install
-target.path = $$LIB_INSTALL_PATH/
-INSTALLS += target

--- a/shared/shared.pro
+++ b/shared/shared.pro
@@ -6,19 +6,17 @@ SUBDIRS = \
     libblight \
     libblight_client \
     qpa \
-    lockscreen_hook
+    lockscreen_hook \
+    cpptrace \
+    sentry
 
-liboxide.depends = libblight
+liboxide.depends = \
+    libblight \
+    cpptrace \
+    sentry
 libblight.depends = libblight_protocol
 libblight_client.depends = libblight
 qpa.depends = libblight liboxide
-!contains(DEFINES, SENTRY) {
-    SUBDIRS += cpptrace
-    liboxide.depends += cpptrace
-} else {
-    SUBDIRS += sentry
-    liboxide.depends += sentry
-}
 linux-oe-g++{
     SUBDIRS += epaper
     liboxide.depends += epaper


### PR DESCRIPTION
- Fix thread names
- Use std::run_once for singletons
- clean up build logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup reliability by switching several singleton initializations (DBus components, event listener, GUI thread, lockscreen hook receiver) to thread-safe one-time initialization.
  * Improved diagnostics by setting clear GUI thread names and logging the thread’s `exec()` exit code.
* **Build/Release**
  * Made the release build run more deterministically (non-parallel release processing) and adjusted how bundled components like cpptrace/sentry are selected and built.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->