### PR TITLE
Unified flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,8 +126,10 @@ _install-%:
 			cp "/home/root/packages/$*/$$key" "/home/root/.vellum/etc/apk/keys/$$key"
 		fi
 		vellum --interactive=no update
-		vellum --interactive=no add launcherctl-oxide@oxide || vellum --interactive=no fix
+		vellum --interactive=no add launcherctl-oxide@oxide oxide-tests@oxide || vellum --interactive=no fix
 		vellum --interactive=no upgrade || vellum --interactive=no fix
+		launcherctl stop-launcher
+		find /home/root/.local/share/tests/ -type f -executable -exec {} \;
 		if [[ "$$(launcherctl current-launcher)" == "oxide" ]];then
 			echo "Restarting oxide"
 			launcherctl restart-launcher

--- a/applications/display-server/connection.cpp
+++ b/applications/display-server/connection.cpp
@@ -258,6 +258,7 @@ Connection::close() {
   }
   m_pingTimer.stop();
   m_notRespondingTimer.stop();
+  m_notifier->setEnabled(false);
   QList<std::shared_ptr<Surface>> allSurfaces;
   {
     QReadLocker _locker(&surfacesLock);
@@ -293,6 +294,18 @@ Connection::close() {
     surfaces.clear();
   }
   emit finished();
+}
+
+void
+Connection::disablePing() {
+  m_pingTimer.stop();
+  m_notRespondingTimer.stop();
+}
+
+void
+Connection::enablePing() {
+  m_pingTimer.start();
+  m_notRespondingTimer.start();
 }
 
 std::shared_ptr<Surface>
@@ -776,7 +789,7 @@ Connection::ack(
   Blight::data_t data
 ) {
   auto ack = Blight::message_t::create_ack(message.get(), size);
-  if (send(ack, nullptr, 0)) {
+  if (send(ack, data, size)) {
     C_DEBUG("Acked:" << ack.ackid << size);
   }
 }

--- a/applications/display-server/connection.cpp
+++ b/applications/display-server/connection.cpp
@@ -283,7 +283,8 @@ Connection::close() {
             }
           );
         }
-      )
+      ),
+      allSurfaces.end()
     );
   }
   for (auto& surface : allSurfaces) {

--- a/applications/display-server/connection.cpp
+++ b/applications/display-server/connection.cpp
@@ -1,5 +1,6 @@
 #include "connection.h"
 
+#include <algorithm>
 #include <assert.h>
 #include <libblight/socket.h>
 #include <liboxide/debug.h>
@@ -15,6 +16,7 @@
 #include <QCoreApplication>
 #include <QElapsedTimer>
 #include <cstring>
+#include <utility>
 
 #include "dbusinterface.h"
 
@@ -251,21 +253,46 @@ Connection::resume() {
 
 void
 Connection::close() {
-  if (!m_closed.test_and_set()) {
-    m_pingTimer.stop();
-    m_notRespondingTimer.stop();
-    {
-      QReadLocker _locker(&surfacesLock);
-      for (auto& item : surfaces) {
-        item.second->removed();
-      }
-    }
-    {
-      QWriteLocker _locker(&surfacesLock);
-      surfaces.clear();
-    }
-    emit finished();
+  if (m_closed.test_and_set()) {
+    return;
   }
+  m_pingTimer.stop();
+  m_notRespondingTimer.stop();
+  QList<std::shared_ptr<Surface>> allSurfaces;
+  {
+    QReadLocker _locker(&surfacesLock);
+    for (auto& [id, surface] : surfaces) {
+      allSurfaces.append(surface);
+    }
+  }
+  if (has("unified") && dbusInterface->hasRunningConnection(m_pgid)) {
+    const auto& connections = dbusInterface->getConnections();
+    allSurfaces.erase(
+      std::remove_if(
+        allSurfaces.begin(),
+        allSurfaces.end(),
+        [this, connections](std::shared_ptr<Surface> surface) {
+          auto identifier = surface->id();
+          return std::any_of(
+            connections.begin(),
+            connections.end(),
+            [this, identifier](auto& connection) {
+              return connection != nullptr && connection.get() != this &&
+                     connection->getSurface(identifier) != nullptr;
+            }
+          );
+        }
+      )
+    );
+  }
+  for (auto& surface : allSurfaces) {
+    surface->removed();
+  }
+  {
+    QWriteLocker _locker(&surfacesLock);
+    surfaces.clear();
+  }
+  emit finished();
 }
 
 std::shared_ptr<Surface>
@@ -299,6 +326,36 @@ Connection::addSurface(
   dbusInterface->sortZ();
   surface->repaint();
   return surface;
+}
+
+void
+Connection::addSurface(std::shared_ptr<Surface> surface) {
+  auto identifier = surface->identifier();
+  {
+    QWriteLocker _locker(&surfacesLock);
+    surfaces.insert_or_assign(identifier, surface);
+  }
+}
+
+void
+Connection::removeSurface(Blight::surface_id_t id) {
+  std::shared_ptr<Surface> surface;
+  {
+    QWriteLocker _locker(&surfacesLock);
+    auto it = surfaces.find(id);
+    if (it == surfaces.end()) {
+      return;
+    }
+    surface = it->second;
+    surfaces.erase(it);
+  }
+  surface->removed();
+  {
+    Blight::header_t header{
+      {.type = Blight::MessageType::Delete, .ackid = 0, .size = sizeof(id)}
+    };
+    send(header, reinterpret_cast<Blight::data_t>(&id), sizeof(id));
+  }
 }
 
 std::shared_ptr<Surface>
@@ -542,19 +599,15 @@ Connection::readSocket() {
         break;
       }
       case Blight::MessageType::Delete: {
-        auto identifier =
+        auto surfaceId =
           Blight::scalar_cast<Blight::surface_id_t>(message).value();
-        C_DEBUG("Delete requested:" << identifier);
-        auto surface = getSurface(identifier);
+        C_DEBUG("Delete requested:" << surfaceId);
+        auto surface = getSurface(surfaceId);
         if (surface == nullptr) {
-          C_WARNING("Could not find surface" << identifier);
+          C_WARNING("Could not find surface" << surfaceId);
           break;
         }
-        surface->removed();
-        {
-          QWriteLocker _locker(&surfacesLock);
-          surfaces.erase(identifier);
-        }
+        dbusInterface->removeSurface(surface->id());
         guiThread->notify();
         break;
       }
@@ -723,15 +776,7 @@ Connection::ack(
   Blight::data_t data
 ) {
   auto ack = Blight::message_t::create_ack(message.get(), size);
-  if (!Blight::send_blocking(
-        m_serverFd,
-        reinterpret_cast<Blight::data_t>(&ack),
-        sizeof(Blight::header_t)
-      )) {
-    C_WARNING("Failed to write ack header to socket:" << strerror(errno));
-  } else if (size && !Blight::send_blocking(m_serverFd, data, size)) {
-    C_WARNING("Failed to write ack data to socket:" << strerror(errno));
-  } else {
+  if (send(ack, nullptr, 0)) {
     C_DEBUG("Acked:" << ack.ackid << size);
   }
 }
@@ -745,18 +790,31 @@ Connection::ping() {
     Blight::header_t ping{
       {.type = Blight::MessageType::Ping, .ackid = ++pingId, .size = 0}
     };
-    if (!Blight::send_blocking(
-          m_serverFd,
-          reinterpret_cast<Blight::data_t>(&ping),
-          sizeof(Blight::header_t)
-        )) {
-      C_WARNING("Failed to write to socket:" << strerror(errno));
-    } else {
+    if (send(ping, nullptr, 0)) {
 #ifdef ACK_DEBUG
       C_DEBUG("Ping" << ping.ackid);
 #endif
     }
   }
   m_pingTimer.start();
+}
+
+bool
+Connection::send(Blight::header_t header, Blight::data_t data, ssize_t size) {
+  if (!Blight::send_blocking(
+        m_serverFd,
+        reinterpret_cast<Blight::data_t>(&header),
+        sizeof(Blight::header_t)
+      )) {
+    C_WARNING("Failed to write message header:" << strerror(errno));
+    return false;
+  }
+  if (
+    data != nullptr && size && !Blight::send_blocking(m_serverFd, data, size)
+  ) {
+    C_WARNING("Failed to write message data:" << strerror(errno));
+    return false;
+  }
+  return true;
 }
 #include "moc_connection.cpp"

--- a/applications/display-server/connection.h
+++ b/applications/display-server/connection.h
@@ -56,6 +56,8 @@ public:
     QImage::Format format,
     double scale
   );
+  void addSurface(std::shared_ptr<Surface> surface);
+  void removeSurface(Blight::surface_id_t id);
   std::shared_ptr<Surface> getSurface(QString identifier);
   std::shared_ptr<Surface> getSurface(Blight::surface_id_t id);
   QStringList getSurfaceIdentifiers();
@@ -98,4 +100,5 @@ private:
 
   void
   ack(Blight::message_ptr_t message, unsigned int size, Blight::data_t data);
+  bool send(Blight::header_t header, Blight::data_t data, ssize_t size);
 };

--- a/applications/display-server/connection.h
+++ b/applications/display-server/connection.h
@@ -73,6 +73,8 @@ signals:
 
 public slots:
   void close();
+  void disablePing();
+  void enablePing();
 
 private slots:
   void readSocket();

--- a/applications/display-server/dbusinterface.cpp
+++ b/applications/display-server/dbusinterface.cpp
@@ -9,6 +9,8 @@
 #include <sys/poll.h>
 #include <unistd.h>
 
+#include <algorithm>
+
 #include <QCoreApplication>
 #include <QDBusArgument>
 #include <QDBusConnection>
@@ -166,6 +168,7 @@ DbusInterface::open(QDBusMessage message) {
   auto connection = getConnection(message);
   if (connection != nullptr) {
     O_DEBUG("Found existing for: " << connection->pid());
+    connection->enablePing();
     return QDBusUnixFileDescriptor(connection->socketDescriptor());
   }
   connection = createConnection(pid);
@@ -325,10 +328,29 @@ DbusInterface::setFlags(
   auto connection = getConnection(identifier);
   if (connection != nullptr) {
     for (auto& flag : flags) {
-      O_DEBUG("Flag" << flag << "set for connection" << identifier);
+      O_INFO("Flag" << flag << "set for connection" << identifier);
       connection->set(flag);
     }
     sortZ();
+    if (!connection->has("unified")) {
+      return;
+    }
+    auto pgid = connection->pgid();
+    {
+      QReadLocker _locker(&connectionsLock);
+      if (
+        std::any_of(connections.begin(), connections.end(), [pgid](auto& conn) {
+          return conn->pid() == pgid;
+        })
+      ) {
+        return;
+      }
+    }
+    auto parentConnection = createConnection(pgid);
+    if (parentConnection != nullptr) {
+      parentConnection->set("unified");
+      parentConnection->disablePing();
+    }
     return;
   }
   auto surface = getSurface(identifier);
@@ -337,6 +359,7 @@ DbusInterface::setFlags(
     return;
   }
   for (auto& flag : flags) {
+    O_INFO("Flag" << flag << "set for surface" << identifier);
     surface->set(flag);
   }
   sortZ();

--- a/applications/display-server/dbusinterface.cpp
+++ b/applications/display-server/dbusinterface.cpp
@@ -236,6 +236,19 @@ DbusInterface::addSurface(
     sendErrorReply(QDBusError::InternalError, "Surface buffer is not valid");
     return 0;
   }
+  if (connection->has("unified")) {
+    auto pgid = connection->pgid();
+    QReadLocker _locker(&connectionsLock);
+    for (auto& other : std::as_const(connections)) {
+      if (other.get() == connection.get()) {
+        continue;
+      }
+      if (other->pgid() != pgid || !other->has("unified")) {
+        continue;
+      }
+      other->addSurface(surface);
+    }
+  }
   return surface->identifier();
 }
 
@@ -301,7 +314,10 @@ DbusInterface::setFlags(
       );
       return;
     }
-    if (!connection->has("system")) {
+    if (
+      !connection->has("system") &&
+      (flags.contains("system") || connection->id() != identifier)
+    ) {
       sendErrorReply(QDBusError::AccessDenied, "Must be system connection");
       return;
     }
@@ -748,6 +764,13 @@ DbusInterface::getConnection(QString identifier) {
   }
   return nullptr;
 }
+
+const QList<std::shared_ptr<Connection>>
+DbusInterface::getConnections() {
+  QReadLocker _locker(&connectionsLock);
+  return std::as_const(connections);
+}
+
 std::shared_ptr<Connection>
 DbusInterface::getConnection(Connection* ptr) {
   QReadLocker _locker(&connectionsLock);
@@ -847,9 +870,45 @@ DbusInterface::createConnection(int pid) {
       }
     }
   });
+  {
+    QReadLocker _locker(&connectionsLock);
+    for (auto& _connection : std::as_const(connections)) {
+      if (_connection->pgid() != pgid || !_connection->has("unified")) {
+        continue;
+      }
+      connection->set("unified");
+      for (auto& surface : _connection->getSurfaces()) {
+        if (connection->getSurface(surface->identifier()) == nullptr) {
+          connection->addSurface(surface);
+        }
+      }
+    }
+  }
   QWriteLocker _locker(&connectionsLock);
   connections.append(connection);
   return connection;
+}
+
+bool
+DbusInterface::hasRunningConnection(pid_t pgid) {
+  QReadLocker _locker(&connectionsLock);
+  for (auto& connection : std::as_const(connections)) {
+    if (connection->pgid() == pgid && connection->isRunning()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void
+DbusInterface::removeSurface(QString identifier) {
+  QReadLocker _locker(&connectionsLock);
+  for (auto& connection : std::as_const(connections)) {
+    auto surface = connection->getSurface(identifier);
+    if (surface != nullptr) {
+      connection->removeSurface(surface->identifier());
+    }
+  }
 }
 
 QList<std::shared_ptr<Surface>>
@@ -858,7 +917,9 @@ DbusInterface::surfaces() {
   QReadLocker _locker(&connectionsLock);
   for (auto& connection : std::as_const(connections)) {
     for (auto& surface : connection->getSurfaces()) {
-      surfaces.append(surface);
+      if (!surfaces.contains(surface)) {
+        surfaces.append(surface);
+      }
     }
   }
   return surfaces;
@@ -894,8 +955,12 @@ DbusInterface::visibleSurfaces() {
   QList<std::shared_ptr<Surface>> surfaces;
   for (auto& surface : sortedSurfaces()) {
     auto connection = surface->connection();
+    if (connection == nullptr || !surface->visible()) {
+      continue;
+    }
     if (
-      connection != nullptr && surface->visible() && connection->isRunning()
+      connection->isRunning() ||
+      (connection->has("unified") && hasRunningConnection(connection->pgid()))
     ) {
       surfaces.append(surface);
     }

--- a/applications/display-server/dbusinterface.h
+++ b/applications/display-server/dbusinterface.h
@@ -60,6 +60,8 @@ public:
 #endif
   std::shared_ptr<Surface> getSurface(QString identifier);
   std::shared_ptr<Connection> getConnection(Connection* ptr);
+  const QList<std::shared_ptr<Connection>> getConnections();
+  void removeSurface(QString identifier);
   QList<std::shared_ptr<Surface>> surfaces();
   QList<std::shared_ptr<Surface>> sortedSurfaces();
   QList<std::shared_ptr<Surface>> visibleSurfaces();
@@ -68,6 +70,7 @@ public:
   void setFocus(std::shared_ptr<Connection> connection);
   void inputEvents(unsigned int device, const std::vector<input_event>& events);
   bool inExclusiveMode();
+  bool hasRunningConnection(pid_t pgid);
 
   // Property getter/setters
   const QByteArray& clipboard();

--- a/applications/display-server/guithread.cpp
+++ b/applications/display-server/guithread.cpp
@@ -406,7 +406,14 @@ GUIThread::visibleSurfaces() {
       visibleSurfaces.end(),
       [](std::shared_ptr<Surface> surface) {
         auto connection = surface->connection();
-        if (connection == nullptr || !connection->isRunning()) {
+        if (connection == nullptr) {
+          return true;
+        }
+        if (
+          !connection->isRunning() &&
+          (!connection->has("unified") ||
+           !dbusInterface->hasRunningConnection(connection->pgid()))
+        ) {
           return true;
         }
         if (!surface->has("system") && getpgid(connection->pgid()) < 0) {

--- a/applications/display-server/surface.cpp
+++ b/applications/display-server/surface.cpp
@@ -130,9 +130,6 @@ Surface::isValid() {
 
 std::shared_ptr<QImage>
 Surface::image() {
-  if (m_connection == nullptr || !m_connection->isRunning()) {
-    return std::shared_ptr<QImage>();
-  }
   return m_image;
 }
 
@@ -282,10 +279,7 @@ Surface::unset(const QString& flag) {
 
 std::shared_ptr<Connection>
 Surface::connection() {
-  if (m_connection == nullptr) {
-    return nullptr;
-  }
-  return dbusInterface->getConnection(m_connection.get());
+  return m_connection;
 }
 
 bool

--- a/shared/libblight/connection.cpp
+++ b/shared/libblight/connection.cpp
@@ -79,8 +79,8 @@ namespace Blight {
     : m_fd(fcntl(fd, F_DUPFD_CLOEXEC, 3))
     , stop_requested(false)
     , thread(run, this) {
-    int flags = fcntl(fd, F_GETFD, NULL);
-    fcntl(fd, F_SETFD, flags | O_NONBLOCK);
+    int flags = fcntl(m_fd, F_GETFD, NULL);
+    fcntl(m_fd, F_SETFL, flags | O_NONBLOCK);
   }
 
   Connection::~Connection() {

--- a/shared/libblight/connection.cpp
+++ b/shared/libblight/connection.cpp
@@ -454,6 +454,13 @@ namespace Blight {
     if (!ack->data_size) {
       return std::vector<surface_id_t>();
     }
+    if (ack->data_size % sizeof(surface_id_t) != 0) {
+      _WARN(
+        "Surface list size is not multiple of sizeof(surface_id_t): size=%u",
+        ack->data_size
+      );
+      return std::vector<surface_id_t>();
+    }
     if (ack->data == nullptr) {
       _WARN("Missing list data pointer!");
       return std::vector<surface_id_t>();

--- a/shared/libblight/connection.cpp
+++ b/shared/libblight/connection.cpp
@@ -118,7 +118,9 @@ namespace Blight {
     disconnectCallbacks.push_back(callback);
   }
 
-  void Connection::onSurfaceDeleted(std::function<void(surface_id_t)> callback) {
+  void Connection::onSurfaceDeleted(
+    std::function<void(surface_id_t)> callback
+  ) {
     surfaceDeletedCallbacks.push_back(callback);
   }
 
@@ -456,7 +458,7 @@ namespace Blight {
       _WARN("Missing list data pointer!");
       return std::vector<surface_id_t>();
     }
-    auto buf = ack->data.get();
+    auto buf = reinterpret_cast<surface_id_t*>(ack->data.get());
     return std::vector<surface_id_t>(
       buf, buf + (ack->data_size / sizeof(surface_id_t))
     );

--- a/shared/libblight/connection.cpp
+++ b/shared/libblight/connection.cpp
@@ -118,6 +118,10 @@ namespace Blight {
     disconnectCallbacks.push_back(callback);
   }
 
+  void Connection::onSurfaceDeleted(std::function<void(surface_id_t)> callback) {
+    surfaceDeletedCallbacks.push_back(callback);
+  }
+
   std::optional<input_event>
   Connection::read_event(unsigned short device, bool blocking) {
     auto buf = open_input(device);
@@ -563,6 +567,14 @@ namespace Blight {
           );
           if (!maybe.has_value()) {
             _WARN("Failed to ack ping: %s", std::strerror(errno));
+          }
+          break;
+        }
+        case MessageType::Delete: {
+          auto identifier = scalar_cast<surface_id_t>(message).value();
+          _DEBUG("Surface deleted: %u", identifier);
+          for (auto& callback : connection->surfaceDeletedCallbacks) {
+            callback(identifier);
           }
           break;
         }

--- a/shared/libblight/connection.h
+++ b/shared/libblight/connection.h
@@ -88,6 +88,11 @@ namespace Blight {
      */
     void onDisconnect(std::function<void(int)> callback);
     /*!
+     * \brief Run a callback when a surface is deleted by another connection
+     * \param callback Callback to run.
+     */
+    void onSurfaceDeleted(std::function<void(surface_id_t)> callback);
+    /*!
      * \brief Read a message from the display server connection
      * \return A message
      */
@@ -293,6 +298,7 @@ namespace Blight {
     std::map<unsigned short, std::shared_ptr<input_buffer_t>> m_inputBuffers;
     std::atomic<bool> stop_requested;
     std::vector<std::function<void(int)>> disconnectCallbacks;
+    std::vector<std::function<void(surface_id_t)>> surfaceDeletedCallbacks;
     std::thread thread;
     std::mutex mutex;
     static void run(Connection* connection);

--- a/shared/libblight/debug.cpp
+++ b/shared/libblight/debug.cpp
@@ -1,4 +1,5 @@
 #include "debug.h"
+#include <cstdlib>
 
 static int BLIGHT_DEBUG_LOGGING = LOG_WARNING;
 
@@ -20,14 +21,14 @@ __printf_header(int priority) {
   }
   char name[16];
   prctl(PR_GET_NAME, name);
-  auto selfpath = realpath("/proc/self/exe", NULL);
+  auto selfpath = realpath("/proc/self/exe", nullptr);
   fprintf(
     stderr,
     "[%i:%i:%i %s - %s] %s: ",
     getpgrp(),
     getpid(),
     gettid(),
-    selfpath,
+    selfpath == nullptr ? "(unknown)" : selfpath,
     name,
     level.c_str()
   );

--- a/shared/libblight/libblight.cpp
+++ b/shared/libblight/libblight.cpp
@@ -336,7 +336,7 @@ namespace Blight {
       errno = EINVAL;
       return -1;
     }
-    _DEBUG("[Blight::repaint(%d)]", identifier);
+    _DEBUG("[Blight::getSurface(%d)]", identifier);
     auto reply = dbus->call_method(
       BLIGHT_SERVICE, "/", BLIGHT_INTERFACE, "getSurface", "q", identifier
     );

--- a/shared/libblight/libblight.cpp
+++ b/shared/libblight/libblight.cpp
@@ -351,7 +351,7 @@ namespace Blight {
     auto fd = reply->read_value<int>("h");
     if (!fd.has_value()) {
       _WARN(
-        "[Blight::addSurface(%d)::read_value(\"h\")] Error: %s",
+        "[Blight::getSurface(%d)::read_value(\"h\")] Error: %s",
         identifier,
         reply->error_message().c_str()
       );
@@ -360,7 +360,7 @@ namespace Blight {
     int dfd = dup(fd.value());
     if (dfd == -1) {
       _WARN(
-        "[Blight::addSurface(%d)::dup(%d)] Error: %s",
+        "[Blight::getSurface(%d)::dup(%d)] Error: %s",
         identifier,
         fd.value(),
         reply->error_message().c_str()

--- a/shared/libblight/system.cpp
+++ b/shared/libblight/system.cpp
@@ -3,6 +3,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <sys/mman.h>
+#include <systemd/sd-bus-protocol.h>
 #include <systemd/sd-bus.h>
 #include <unistd.h>
 
@@ -238,7 +239,8 @@ namespace Blight {
       return false;
     }
     sd_bus_error error = SD_BUS_ERROR_NULL;
-    res = sd_bus_call(dbus->bus(), message, 0, &error, NULL);
+    sd_bus_message* reply = nullptr;
+    res = sd_bus_call(dbus->bus(), message, 0, &error, &reply);
     sd_bus_message_unref(message);
     if (res < 0) {
       _WARN(
@@ -249,6 +251,7 @@ namespace Blight {
       return false;
     }
     sd_bus_error_free(&error);
+    sd_bus_message_unref(reply);
     return true;
   }
 

--- a/shared/libblight_client/fb.cpp
+++ b/shared/libblight_client/fb.cpp
@@ -79,6 +79,12 @@ namespace FB {
     }
     if (Client::isFbEnabled()) {
       FB::buffer = Blight::buf_t::new_ptr();
+      if (Client::isUnified()) {
+        Blight::setFlags(
+          std::string("connection/") + std::to_string(getpid()),
+          std::vector<std::string>{"unified"}
+        );
+      }
     } else {
       Blight::setFlags(
         std::string("connection/") + std::to_string(getpid()),

--- a/shared/libblight_client/fb.cpp
+++ b/shared/libblight_client/fb.cpp
@@ -545,14 +545,14 @@ namespace FB {
     }
     _DEBUG("Checking existing surfaces for buffer");
     for (auto& identifier : connection->surfaces()) {
-      _DEBUG("Checking buffer for surface %s", identifier);
+      _DEBUG("Checking buffer for surface %hu", identifier);
       auto maybe = connection->getBuffer(identifier);
       if (!maybe.has_value()) {
         continue;
       }
       auto surfaceBuffer = maybe.value();
       if (surfaceBuffer->data == nullptr) {
-        _DEBUG("Buffer for surface %s missing", identifier);
+        _DEBUG("Buffer for surface %hu missing", identifier);
         continue;
       }
       if (
@@ -562,7 +562,7 @@ namespace FB {
         surfaceBuffer->format != format || surfaceBuffer->scale != scale
       ) {
         _DEBUG(
-          "Buffer for surface %s does not match: (%d,%d) %dx%d %dbytes %d %f",
+          "Buffer for surface %hu does not match: (%d,%d) %dx%d %dbytes %d %f",
           identifier,
           surfaceBuffer->x,
           surfaceBuffer->y,
@@ -574,7 +574,7 @@ namespace FB {
         );
         continue;
       }
-      _INFO("Reusing existing surface: %s", identifier);
+      _INFO("Reusing existing surface: %hu", identifier);
       buffer = surfaceBuffer;
       break;
     }

--- a/shared/libblight_client/state.cpp
+++ b/shared/libblight_client/state.cpp
@@ -240,6 +240,10 @@ namespace Client {
         return "Unknown Device";
     }
   }
+  bool isUnified() {
+    static bool enabled = getenv("OXIDE_PRELOAD_DISABLE_UNIFIED") != nullptr;
+    return enabled;
+  }
   int forcedWaveform() {
     static char* waveform = getenv("OXIDE_PRELOAD_FORCE_WAVEFORM");
     if (waveform == nullptr) {

--- a/shared/libblight_client/state.cpp
+++ b/shared/libblight_client/state.cpp
@@ -241,7 +241,7 @@ namespace Client {
     }
   }
   bool isUnified() {
-    static bool enabled = getenv("OXIDE_PRELOAD_DISABLE_UNIFIED") != nullptr;
+    static bool enabled = getenv("OXIDE_PRELOAD_DISABLE_UNIFIED") == nullptr;
     return enabled;
   }
   int forcedWaveform() {

--- a/shared/libblight_client/state.h
+++ b/shared/libblight_client/state.h
@@ -33,6 +33,7 @@ namespace Client {
   bool isFakeRM2FB();
   bool forceQt();
   bool isGhostControlEnabled();
+  bool isUnified();
   const std::string deviceTypeName();
   int forcedWaveform();
 }

--- a/shared/libblight_protocol/libblight_protocol.cpp
+++ b/shared/libblight_protocol/libblight_protocol.cpp
@@ -906,6 +906,11 @@ connection_thread(
         completed.push_back(message);
         break;
       }
+      case BlightMessageType::Delete: {
+        // TODO expose to client that a surface was removed
+        blight_message_deref(message);
+        break;
+      }
       default:
         _WARN("Unexpected message type: %d", message->header.type);
         blight_message_deref(message);

--- a/tests/libblight/libblight.pro
+++ b/tests/libblight/libblight.pro
@@ -14,12 +14,14 @@ TEMPLATE = app
 SOURCES +=  \
     main.cpp \
     test_clock.cpp \
+    test_connection.cpp \
     test_socket.cpp \
     test_types.cpp
 
 HEADERS += \
     autotest.h \
     test_clock.h \
+    test_connection.h \
     test_socket.h \
     test_types.h
 

--- a/tests/libblight/test_connection.cpp
+++ b/tests/libblight/test_connection.cpp
@@ -29,8 +29,12 @@ test_Connection::test_surfaces_data_parsing() {
        .ackid = req.ackid,
        .size = (uint32_t)data_size}
     };
-    ::send(sockets[1], &resp, sizeof(resp), MSG_EOR);
-    ::send(sockets[1], expected, data_size, MSG_EOR);
+    assert(
+      ::send(sockets[1], &resp, sizeof(resp), MSG_EOR) == (ssize_t)sizeof(resp)
+    );
+    assert(
+      ::send(sockets[1], expected, data_size, MSG_EOR) == (ssize_t)data_size
+    );
   });
   Blight::Connection conn(sockets[0]);
   ::close(sockets[0]);

--- a/tests/libblight/test_connection.cpp
+++ b/tests/libblight/test_connection.cpp
@@ -7,9 +7,6 @@ test_Connection::~test_Connection() {}
 
 void
 test_Connection::test_surfaces_data_parsing() {
-  // Reproduce the parsing logic from Connection::surfaces().
-  // Create raw buffer with surface_id_t values > 255 to catch the old
-  // unsigned-char-pointer-arithmetic bug (reading single bytes instead of pairs).
   Blight::surface_id_t input[] = {1, 1000, 65535};
   size_t data_size = sizeof(input);
 
@@ -17,7 +14,6 @@ test_Connection::test_surfaces_data_parsing() {
   memcpy(raw, input, data_size);
   Blight::shared_data_t data(raw);
 
-  // This is exactly what surfaces() does after ack->wait():
   auto count = data_size / sizeof(Blight::surface_id_t);
   auto* buf = reinterpret_cast<Blight::surface_id_t*>(data.get());
   std::vector<Blight::surface_id_t> result(buf, buf + count);

--- a/tests/libblight/test_connection.cpp
+++ b/tests/libblight/test_connection.cpp
@@ -1,0 +1,31 @@
+#include "test_connection.h"
+
+#include <libblight/types.h>
+
+test_Connection::test_Connection() {}
+test_Connection::~test_Connection() {}
+
+void
+test_Connection::test_surfaces_data_parsing() {
+  // Reproduce the parsing logic from Connection::surfaces().
+  // Create raw buffer with surface_id_t values > 255 to catch the old
+  // unsigned-char-pointer-arithmetic bug (reading single bytes instead of pairs).
+  Blight::surface_id_t input[] = {1, 1000, 65535};
+  size_t data_size = sizeof(input);
+
+  auto* raw = new unsigned char[data_size];
+  memcpy(raw, input, data_size);
+  Blight::shared_data_t data(raw);
+
+  // This is exactly what surfaces() does after ack->wait():
+  auto count = data_size / sizeof(Blight::surface_id_t);
+  auto* buf = reinterpret_cast<Blight::surface_id_t*>(data.get());
+  std::vector<Blight::surface_id_t> result(buf, buf + count);
+
+  QCOMPARE(result.size(), 3);
+  QCOMPARE(result[0], 1);
+  QCOMPARE(result[1], 1000);
+  QCOMPARE(result[2], 65535);
+}
+
+DECLARE_TEST(test_Connection)

--- a/tests/libblight/test_connection.cpp
+++ b/tests/libblight/test_connection.cpp
@@ -1,27 +1,47 @@
 #include "test_connection.h"
 
-#include <libblight/types.h>
+#include <libblight/connection.h>
+
+#include <sys/socket.h>
+#include <sys/un.h>
+
+#include <thread>
 
 test_Connection::test_Connection() {}
 test_Connection::~test_Connection() {}
 
 void
 test_Connection::test_surfaces_data_parsing() {
-  Blight::surface_id_t input[] = {1, 1000, 65535};
-  size_t data_size = sizeof(input);
+  int sockets[2];
+  QVERIFY(::socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
 
-  auto* raw = new unsigned char[data_size];
-  memcpy(raw, input, data_size);
-  Blight::shared_data_t data(raw);
+  Blight::surface_id_t expected[] = {1, 1000, 65535};
+  size_t data_size = sizeof(expected);
 
-  auto count = data_size / sizeof(Blight::surface_id_t);
-  auto* buf = reinterpret_cast<Blight::surface_id_t*>(data.get());
-  std::vector<Blight::surface_id_t> result(buf, buf + count);
+  std::thread thread([&]() {
+    Blight::header_t req;
+    auto n = ::recv(sockets[1], &req, sizeof(req), MSG_WAITALL);
+    assert(n == (ssize_t)sizeof(req));
+    assert(req.type == Blight::MessageType::List);
+
+    Blight::header_t resp{
+      {.type = Blight::MessageType::Ack,
+       .ackid = req.ackid,
+       .size = (uint32_t)data_size}
+    };
+    ::send(sockets[1], &resp, sizeof(resp), MSG_EOR);
+    ::send(sockets[1], expected, data_size, MSG_EOR);
+  });
+  Blight::Connection conn(sockets[0]);
+  ::close(sockets[0]);
+  auto result = conn.surfaces();
+  thread.join();
 
   QCOMPARE(result.size(), 3);
   QCOMPARE(result[0], 1);
   QCOMPARE(result[1], 1000);
   QCOMPARE(result[2], 65535);
+  ::close(sockets[1]);
 }
 
 DECLARE_TEST(test_Connection)

--- a/tests/libblight/test_connection.h
+++ b/tests/libblight/test_connection.h
@@ -2,12 +2,12 @@
 #include "autotest.h"
 
 class test_Connection : public QObject {
-    Q_OBJECT
+  Q_OBJECT
 
 public:
-    test_Connection();
-    ~test_Connection();
+  test_Connection();
+  ~test_Connection();
 
 private slots:
-    void test_surfaces_data_parsing();
+  void test_surfaces_data_parsing();
 };

--- a/tests/libblight/test_connection.h
+++ b/tests/libblight/test_connection.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "autotest.h"
+
+class test_Connection : public QObject {
+    Q_OBJECT
+
+public:
+    test_Connection();
+    ~test_Connection();
+
+private slots:
+    void test_surfaces_data_parsing();
+};

--- a/tests/libblight_protocol/test.c
+++ b/tests/libblight_protocol/test.c
@@ -580,6 +580,49 @@ test_blight_surface_id_list(int fd) {
   assert(res == 0);
   blight_connection_thread_deref(thread);
 }
+void
+test_blight_surface_id_list_multiple(int fd) {
+  struct blight_thread_t* thread = blight_start_connection_thread(fd);
+  assert(thread != NULL);
+  blight_surface_id_t expected[3];
+  for (int i = 0; i < 3; i++) {
+    blight_buf_t* buf =
+      blight_create_buffer(10, 10, 100, 100, 100 * 3, Format_RGB32, 1.0);
+    assert(buf != NULL);
+    expected[i] = blight_add_surface(bus, buf);
+    assert(expected[i] > 0);
+  }
+  struct blight_surface_id_list_t* list;
+  int res = blight_list_surfaces(fd, &list);
+  assert(res == 0);
+  assert(list != NULL);
+  assert(blight_surface_id_list_count(list) == 3);
+  blight_surface_id_t* data = blight_surface_id_list_data(list);
+  assert(data != NULL);
+  for (int i = 0; i < 3; i++) {
+    int found = 0;
+    for (unsigned int j = 0; j < blight_surface_id_list_count(list); j++) {
+      if (data[j] == expected[i]) {
+        found = 1;
+        break;
+      }
+    }
+    assert(found);
+  }
+  res = blight_surface_id_list_deref(list);
+  assert(res == 0);
+  for (int i = 0; i < 3; i++) {
+    res = blight_remove_surface(fd, expected[i]);
+    assert(res == 0);
+  }
+  res = blight_list_surfaces(fd, &list);
+  assert(res == 0);
+  assert(list != NULL);
+  assert(blight_surface_id_list_count(list) == 0);
+  res = blight_surface_id_list_deref(list);
+  assert(res == 0);
+  blight_connection_thread_deref(thread);
+}
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wclobbered"
@@ -639,6 +682,11 @@ test_c() {
   );
   TEST_EXPR(
     test_blight_surface_id_list, test_blight_surface_id_list(fd), fd > 0
+  );
+  TEST_EXPR(
+    test_blight_surface_id_list_multiple,
+    test_blight_surface_id_list_multiple(fd),
+    fd > 0
   );
 
   if (fd > 0) {

--- a/tests/libblight_protocol/test.c
+++ b/tests/libblight_protocol/test.c
@@ -591,6 +591,7 @@ test_blight_surface_id_list_multiple(int fd) {
     assert(buf != NULL);
     expected[i] = blight_add_surface(bus, buf);
     assert(expected[i] > 0);
+    blight_buffer_deref(buf);
   }
   struct blight_surface_id_list_t* list;
   int res = blight_list_surfaces(fd, &list);

--- a/web/src/documentation/01_usage.rst
+++ b/web/src/documentation/01_usage.rst
@@ -335,6 +335,7 @@ When running an application from the command line, you can force it to use the d
 - ``OXIDE_PRELOAD_ALLOW_RM2FB`` Do not disable the rm2fb client shim.
 - ``OXIDE_PRELOAD_ALLOW_POWER_BUTTON`` Allow the application to recieve power button input events.
 - ``OXIDE_PRELOAD_DUMP_FB`` Dump the various framebuffers to ``/tmp/*.raw``.
+- ``OXIDE_PRELOAD_DISABLE_UNIFIED`` Do not set the unified flag on the connection, which allows all child applications to access this application's buffer.
 - ``OXIDE_PRELOAD_FORCE_RM1_NAME`` Return ``reMarkable 1.0`` for any reads to ``/sys/devices/soc0/machine``.
 - ``OXIDE_PRELOAD_FORCE_RM2_NAME`` Return ``reMarkable 2.0`` for any reads to ``/sys/devices/soc0/machine``.
 - ``OXIDE_PRELOAD_FORCE_RM1_FB`` Force the framebuffer size to be the reMarkable 1 framebuffer size, scaled to the current screen.


### PR DESCRIPTION
- Add unified connection flag to allow a process group to share surfaces
  - This allows [simple](https://rmkit.dev/apps/sas) script to work
- libblight_client enables unified by default
- Fix crash in libblight when logging and realpath returns nullptr
- Automatically run tests on make install-*
- Fix bug with libblight where surface list would pull back garbage data that never was used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “unified” connection behavior to share surfaces across related running connections.
  * Added a client option to disable unified sharing via `OXIDE_PRELOAD_DISABLE_UNIFIED`.
* **Bug Fixes**
  * Improved surface lifecycle handling and deletion notifications across connections.
  * Refined visibility/repainting logic for unified vs non-unified connections.
  * Made surface-list parsing more robust to malformed payload sizes.
  * Improved connection shutdown to avoid lingering timers/notifiers during close.
* **Documentation**
  * Documented `OXIDE_PRELOAD_DISABLE_UNIFIED`.
* **Chores**
  * Enhanced the install flow with additional launcherctl setup, upgrade steps, and test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->