### PR TITLE
Fix #449

### DIFF
--- a/applications/display-server/guithread.cpp
+++ b/applications/display-server/guithread.cpp
@@ -51,7 +51,6 @@ GUIThread::run() {
       eventDispatcher()->processEvents(QEventLoop::AllEvents);
     }
   });
-  clearFrameBuffer();
   setObjectName("GUIThread");
   pthread_setname_np(pthread_self(), "GUIThread");
   auto res = exec();

--- a/applications/launcher/widgets/BetterSpinBox.qml
+++ b/applications/launcher/widgets/BetterSpinBox.qml
@@ -5,10 +5,11 @@ SpinBox {
     id: control
     property bool upPressed: up.pressed
     property bool downPressed: down.pressed
+    leftPadding: padding + (down.indicator ? down.indicator.width : 0)
     up.indicator: Rectangle {
-        x: control.mirrored ? 0 : parent.width - width
-        height: parent.height
-        implicitWidth: 40
+        x: control.mirrored ? 0 : control.width - width
+        height: control.height
+        implicitWidth: 100
         implicitHeight: 40
         visible: control.enabled && control.value < control.to
         color: "white"
@@ -25,9 +26,9 @@ SpinBox {
         }
     }
     down.indicator: Rectangle {
-        x: control.mirrored ? parent.width - width : 0
-        height: parent.height
-        implicitWidth: 40
+        x: control.mirrored ? control.width - width : 0
+        height: control.height
+        implicitWidth: 100
         implicitHeight: 40
         visible: control.enabled && control.value > control.from
         color: "white"

--- a/applications/launcher/widgets/BetterSpinBox.qml
+++ b/applications/launcher/widgets/BetterSpinBox.qml
@@ -5,7 +5,11 @@ SpinBox {
     id: control
     property bool upPressed: up.pressed
     property bool downPressed: down.pressed
-    leftPadding: padding + (down.indicator ? down.indicator.width : 0)
+    leftPadding: padding + (
+        control.mirrored
+        ? (down.indicator ? down.indicator.width : 0)
+        : (up.indicator ? up.indicator.width : 0)
+    )
     up.indicator: Rectangle {
         x: control.mirrored ? 0 : control.width - width
         height: control.height


### PR DESCRIPTION
Increase spinbox button sizes, fix spinbox content overlapping with decrement button

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spin box layout so arrow indicators have more space and align more reliably, including when mirroring is enabled.
  * Enhanced display-thread behavior by explicitly processing pending Qt events during repaint handling, improving overall responsiveness during frequent UI updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->