### PR TITLE
Add extra swapBuffers guard, fix CPU usage issue on aarch64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ _install-%:
 	EOT
 
 .PHONY: build-rm1
-build-rm1: clean-base $(DIST)
+build-rm1: $(DIST)
 	podman run \
 		--env BUILDNAME=oxide-rm1 \
 		--rm \
@@ -150,7 +150,7 @@ build-rm1: clean-base $(DIST)
 		bash -exc 'apt-get update; apt-get install -y clang-format;source /opt/codex/rm1/$(TOOLCHAIN)/environment-setup-cortexa9hf-neon-remarkable-linux-gnueabi; make FEATURES=$(FEATURES) release'
 
 .PHONY: build-rm2
-build-rm2: clean-base $(DIST)
+build-rm2: $(DIST)
 	podman run \
 		--env BUILDNAME=oxide-rm2 \
 		--rm \
@@ -160,7 +160,7 @@ build-rm2: clean-base $(DIST)
 		bash -exc 'apt-get update; apt-get install -y clang-format;source /opt/codex/rm2/$(TOOLCHAIN)/environment-setup-cortexa7hf-neon-remarkable-linux-gnueabi; make FEATURES=$(FEATURES) release'
 
 .PHONY: build-rmpp
-build-rmpp: clean-base $(DIST)
+build-rmpp: $(DIST)
 	podman run \
 		--env BUILDNAME=oxide-rmpp \
 		--rm \
@@ -170,7 +170,7 @@ build-rmpp: clean-base $(DIST)
 		bash -exc 'apt-get update; apt-get install -y clang-format;source /opt/codex/ferrari/$(TOOLCHAIN)/environment-setup-cortexa53-crypto-remarkable-linux; make FEATURES=$(FEATURES) release'
 
 .PHONY: build-rmppm
-build-rmppm: clean-base $(DIST)
+build-rmppm: $(DIST)
 	podman run \
 		--env BUILDNAME=oxide-rmppm \
 		--rm \
@@ -180,7 +180,7 @@ build-rmppm: clean-base $(DIST)
 		bash -exc 'apt-get update; apt-get install -y clang-format;source /opt/codex/chiappa/$(TOOLCHAIN)/environment-setup-cortexa55-remarkable-linux; make FEATURES=$(FEATURES) release'
 
 .PHONY: build-rmppure
-build-rmppure: clean-base $(DIST)
+build-rmppure: $(DIST)
 	podman run \
 		--env BUILDNAME=oxide-rmppure \
 		--rm \

--- a/shared/libblight_client/input.cpp
+++ b/shared/libblight_client/input.cpp
@@ -13,7 +13,6 @@
 #include <fcntl.h>
 #include <libblight/debug.h>
 #include <linux/input-event-codes.h>
-#include <linux/input.h>
 #include <linux/prctl.h>
 #include <map>
 #include <mutex>
@@ -100,6 +99,19 @@ namespace Input {
     }
     thread = nullptr;
     _DEBUG("Input[%d] Stopped", device);
+  }
+  std::optional<input_event> DeviceInfo::read(bool blocking) {
+    std::optional<input_event> maybe;
+    if (blocking) {
+      maybe = ringBuffer->wait_for_values();
+    } else {
+      maybe = ringBuffer->take();
+    }
+    if (maybe.has_value()) {
+      uint64_t val;
+      Libc::read(info.eventFd, &val, sizeof(val));
+    }
+    return maybe;
   }
 
   int getEventFd(int fd) {
@@ -1233,8 +1245,7 @@ namespace Input {
     auto& ringBuffer = info.ringBuffer;
     uint64_t val;
     if (ringBuffer->overflowed()) {
-      ringBuffer->take();
-      Libc::read(info.eventFd, &val, sizeof(val));
+      info.read();
       events[count] = {};
       events[count].type = EV_SYN;
       events[count].code = SYN_DROPPED;
@@ -1243,19 +1254,18 @@ namespace Input {
     }
     while (count < size / sizeof(input_event)) {
       if (flags & O_NONBLOCK) {
-        auto maybe = ringBuffer->take();
+        auto maybe = info.read();
         if (!maybe.has_value()) {
           break;
         }
         events[count] = *maybe;
       } else {
-        auto maybe = ringBuffer->wait_for_values();
+        auto maybe = info.read(true);
         if (!maybe.has_value()) {
           break;
         }
         events[count] = *maybe;
       }
-      Libc::read(info.eventFd, &val, sizeof(val));
       count++;
       if (ringBuffer->empty()) {
         break;

--- a/shared/libblight_client/input.cpp
+++ b/shared/libblight_client/input.cpp
@@ -113,6 +113,11 @@ namespace Input {
     }
     return maybe;
   }
+  void DeviceInfo::write(const input_event& event) {
+    ringBuffer->insert(event);
+    uint64_t val = 1;
+    Libc::write(eventFd, &val, sizeof(val));
+  }
 
   int getEventFd(int fd) {
     if (!deviceDescriptors.contains(fd)) {
@@ -611,7 +616,6 @@ namespace Input {
     auto& ringBuffer = info.ringBuffer;
     auto& eventFd = info.eventFd;
     auto& state = info.state;
-    uint64_t eventFdVal = 1;
     _DEBUG(
       "%s reading input buffer for event%d on fd %d",
       name,
@@ -622,8 +626,7 @@ namespace Input {
       if (inputBuffer->ringBuffer->overflowed()) {
         _WARN("%s overflowed", name);
         inputBuffer->read();
-        ringBuffer->insert({.type = EV_SYN, .code = SYN_DROPPED, .value = 1});
-        Libc::write(eventFd, &eventFdVal, sizeof(eventFdVal));
+        info.write({.type = EV_SYN, .code = SYN_DROPPED, .value = 1});
         pending.clear();
       }
       auto maybe = inputBuffer->read(true);
@@ -640,8 +643,7 @@ namespace Input {
         event.value = 0;
       }
       if (!Client::isFakeRM1Input()) {
-        ringBuffer->insert(event);
-        Libc::write(eventFd, &eventFdVal, sizeof(eventFdVal));
+        info.write(event);
         continue;
       }
       pending.push_back(event);
@@ -822,8 +824,7 @@ namespace Input {
         ) {
           continue;
         }
-        ringBuffer->insert(pendingEvent);
-        Libc::write(eventFd, &eventFdVal, sizeof(eventFdVal));
+        info.write(pendingEvent);
       }
       pending.clear();
     }
@@ -1234,11 +1235,6 @@ namespace Input {
       device = info.device;
       flags = info.flags;
     }
-    // TODO only implement after blocking getdents and getdents64 reults
-    // if (Client::isFakeRM1Input() && device > 2 && flags & O_NONBLOCK) {
-    //   errno = EAGAIN;
-    //   return -1;
-    // }
     auto* events = static_cast<input_event*>(buf);
     size_t count = 0;
     auto& info = *devices.at(device);

--- a/shared/libblight_client/input.cpp
+++ b/shared/libblight_client/input.cpp
@@ -109,7 +109,7 @@ namespace Input {
     }
     if (maybe.has_value()) {
       uint64_t val;
-      Libc::read(info.eventFd, &val, sizeof(val));
+      Libc::read(eventFd, &val, sizeof(val));
     }
     return maybe;
   }

--- a/shared/libblight_client/input.cpp
+++ b/shared/libblight_client/input.cpp
@@ -824,7 +824,7 @@ namespace Input {
         ) {
           continue;
         }
-        write(pendingEvent);
+        info.write(pendingEvent);
       }
       pending.clear();
     }

--- a/shared/libblight_client/input.cpp
+++ b/shared/libblight_client/input.cpp
@@ -1231,8 +1231,10 @@ namespace Input {
     size_t count = 0;
     auto& info = *devices.at(device);
     auto& ringBuffer = info.ringBuffer;
+    uint64_t val;
     if (ringBuffer->overflowed()) {
       ringBuffer->take();
+      Libc::read(info.eventFd, &val, sizeof(val));
       events[count] = {};
       events[count].type = EV_SYN;
       events[count].code = SYN_DROPPED;
@@ -1253,7 +1255,6 @@ namespace Input {
         }
         events[count] = *maybe;
       }
-      uint64_t val;
       Libc::read(info.eventFd, &val, sizeof(val));
       count++;
       if (ringBuffer->empty()) {

--- a/shared/libblight_client/input.cpp
+++ b/shared/libblight_client/input.cpp
@@ -824,7 +824,7 @@ namespace Input {
         ) {
           continue;
         }
-        info.write(pendingEvent);
+        write(pendingEvent);
       }
       pending.clear();
     }
@@ -891,7 +891,7 @@ namespace Input {
       info.ringBuffer = std::make_shared<Blight::EvdevRingBuffer>(true);
     }
     if (info.eventFd == -1) {
-      int eventFd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+      int eventFd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC | EFD_SEMAPHORE);
       if (eventFd < 0) {
         _WARN("Failed to create eventfd: %s", std::strerror(errno));
         return -1;

--- a/shared/libblight_client/input.h
+++ b/shared/libblight_client/input.h
@@ -6,7 +6,9 @@
 #include <cstddef>
 #include <cstdlib>
 #include <cstring>
+#include <linux/input.h>
 #include <memory>
+#include <optional>
 #include <poll.h>
 #include <string>
 #include <sys/epoll.h>
@@ -56,6 +58,7 @@ namespace Input {
     );
     ~DeviceInfo();
     void stop();
+    std::optional<input_event> read(bool blocking = false);
   };
   struct DeviceMap {
     unsigned short device;

--- a/shared/libblight_client/input.h
+++ b/shared/libblight_client/input.h
@@ -59,6 +59,7 @@ namespace Input {
     ~DeviceInfo();
     void stop();
     std::optional<input_event> read(bool blocking = false);
+    void write(const input_event& event);
   };
   struct DeviceMap {
     unsigned short device;

--- a/shared/libblight_client/main.cpp
+++ b/shared/libblight_client/main.cpp
@@ -531,6 +531,7 @@ poll(struct pollfd* fds, nfds_t nfds, int timeout) {
   return res;
 }
 
+#ifdef __aarch64__
 __attribute__((visibility("default"))) int
 ppoll(
   struct pollfd* fds,
@@ -551,6 +552,7 @@ ppoll(
   }
   return res;
 }
+#endif
 
 __attribute__((visibility("default"))) int
 __ppoll64(

--- a/shared/libblight_client/main.cpp
+++ b/shared/libblight_client/main.cpp
@@ -532,6 +532,27 @@ poll(struct pollfd* fds, nfds_t nfds, int timeout) {
 }
 
 __attribute__((visibility("default"))) int
+ppoll(
+  struct pollfd* fds,
+  nfds_t nfds,
+  const struct timespec* tmo,
+  const sigset_t* sigmask
+) {
+  struct pollfd* backup = nullptr;
+  if (Client::INITIALIZED && Client::isInputEnabled()) {
+    backup = Input::translatePollfds(fds, nfds);
+  }
+  int res = Libc::ppoll(fds, nfds, tmo, sigmask);
+  if (res == 0 && nfds > 0 && tmo == nullptr) {
+    _WARN("ppoll exited early with no revents");
+  }
+  if (backup != nullptr) {
+    Input::restorePollfds(fds, nfds, backup);
+  }
+  return res;
+}
+
+__attribute__((visibility("default"))) int
 __ppoll64(
   struct pollfd* fds,
   nfds_t nfds,

--- a/shared/libblight_client/qt.cpp
+++ b/shared/libblight_client/qt.cpp
@@ -514,6 +514,11 @@ validate_swapbuffers(void* func) {
     _WARN("swapBuffers: nullptr")
     return false;
   }
+  Dl_info info;
+  if (dladdr(func, &info) == 0) {
+    _WARN("swapBuffers: address %p not in process address space", func);
+    return false;
+  }
 #if defined(__arm__)
   // Check arm32 prologue for the swapBuffers(QRegion) variant:
   //   stmdb sp!,{r4-r11,lr}   (0xE92D4FF0)

--- a/shared/libblight_client/qt.cpp
+++ b/shared/libblight_client/qt.cpp
@@ -514,6 +514,21 @@ validate_swapbuffers(void* func) {
     _WARN("swapBuffers: nullptr")
     return false;
   }
+#if defined(__arm__)
+  if (reinterpret_cast<uintptr_t>(func) & 2) {
+    _WARN("swapBuffers: address %p is not 2-byte aligned", func);
+    return false;
+  }
+#elif defined(__aarch64__)
+  if (reinterpret_cast<uintptr_t>(func) & 3) {
+    _WARN("swapBuffers: address %p is not 4-byte aligned", func);
+    return false;
+  }
+#else
+  _CRIT("%s", "Unsupported architecture");
+  std::exit(EXIT_FAILURE);
+  return false;
+#endif
   Dl_info info;
   if (dladdr(func, &info) == 0) {
     _WARN("swapBuffers: address %p not in process address space", func);
@@ -567,10 +582,6 @@ validate_swapbuffers(void* func) {
     }
   }
   _WARN("swapBuffers: PAC prologue not found")
-  return false;
-#else
-  _CRIT("%s", "Unsupported architecture");
-  std::exit(EXIT_FAILURE);
   return false;
 #endif
 }

--- a/shared/libblight_client/qt.cpp
+++ b/shared/libblight_client/qt.cpp
@@ -11,6 +11,7 @@
 #include <libblight/system.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
+#include <sys/uio.h>
 #include <unistd.h>
 
 #include <atomic>
@@ -532,6 +533,15 @@ validate_swapbuffers(void* func) {
   Dl_info info;
   if (dladdr(func, &info) == 0) {
     _WARN("swapBuffers: address %p not in process address space", func);
+    return false;
+  }
+  char buf[4];
+  struct iovec local = {.iov_base = buf, .iov_len = sizeof(uint32_t)};
+  struct iovec remote = {.iov_base = func, .iov_len = sizeof(uint32_t)};
+  if (
+    process_vm_readv(getpid(), &local, 1, &remote, 1, 0) != sizeof(uint32_t)
+  ) {
+    _WARN("swapBuffers: address %p not readable", func);
     return false;
   }
 #if defined(__arm__)

--- a/shared/libblight_client/qt.cpp
+++ b/shared/libblight_client/qt.cpp
@@ -512,7 +512,7 @@ install_hook(void* target, void* hook) {
 bool
 validate_swapbuffers(void* func) {
   if (func == nullptr) {
-    _WARN("swapBuffers: nullptr")
+    _WARN("swapBuffers: nullptr");
     return false;
   }
 #if defined(__arm__)
@@ -535,12 +535,10 @@ validate_swapbuffers(void* func) {
     _WARN("swapBuffers: address %p not in process address space", func);
     return false;
   }
-  char buf[4];
-  struct iovec local = {.iov_base = buf, .iov_len = sizeof(uint32_t)};
-  struct iovec remote = {.iov_base = func, .iov_len = sizeof(uint32_t)};
-  if (
-    process_vm_readv(getpid(), &local, 1, &remote, 1, 0) != sizeof(uint32_t)
-  ) {
+  uint32_t data[2];
+  struct iovec local = {.iov_base = data, .iov_len = sizeof(data)};
+  struct iovec remote = {.iov_base = func, .iov_len = sizeof(data)};
+  if (process_vm_readv(getpid(), &local, 1, &remote, 1, 0) != sizeof(data)) {
     _WARN("swapBuffers: address %p not readable", func);
     return false;
   }
@@ -548,7 +546,6 @@ validate_swapbuffers(void* func) {
   // Check arm32 prologue for the swapBuffers(QRegion) variant:
   //   stmdb sp!,{r4-r11,lr}   (0xE92D4FF0)
   //   sub sp, sp, #0x44       (0xE24DD044)
-  auto data = reinterpret_cast<uint32_t*>(func);
   // Try the QRegion pattern: STMDB SP!,{...,LR} / SUB SP,#0x44
   if ((data[0] & 0xFFFF0000) == 0xE92D0000 && (data[0] & 0x4000)) {
     if (data[1] == 0xE24DD044) {
@@ -578,7 +575,6 @@ validate_swapbuffers(void* func) {
   // followed by either:
   //   stp x29, x30, [sp, #-imm]!  (frame pointer)
   //   sub sp, sp, #imm             (no frame pointer)
-  auto data = reinterpret_cast<uint32_t*>(func);
   if ((data[0] & 0xFFC00000) == 0xA9800000) {
     return true;
   }
@@ -591,7 +587,7 @@ validate_swapbuffers(void* func) {
       return true;
     }
   }
-  _WARN("swapBuffers: PAC prologue not found")
+  _WARN("swapBuffers: PAC prologue not found");
   return false;
 #endif
 }

--- a/shared/libblight_client/state.cpp
+++ b/shared/libblight_client/state.cpp
@@ -120,9 +120,6 @@ namespace Client {
     }
   }
   bool isInputEnabled() {
-    if (forceQt()) {
-      return false;
-    }
     return getenv("OXIDE_PRELOAD_EXPOSE_INPUT") == nullptr;
   }
   bool isFbEnabled() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened `swapBuffers` validation by rejecting misaligned function addresses per architecture and halting validation when the address can’t be confirmed in the current process.
* **Improvements**
  * Enhanced input event handling by centralizing ring-buffer + signaling reads/writes, refining overflow and pending-event processing, and using semaphore semantics for `eventfd`.
  * Improved `ppoll` support on `aarch64` when input handling is enabled.
* **Behavior Change**
  * Input exposure no longer gets forcibly disabled in Qt mode; it’s now controlled solely by the `OXIDE_PRELOAD_EXPOSE_INPUT` environment setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->