### PR TITLE
Get building on amd64 with latest qt6 again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,6 +189,10 @@ build-rmppure: $(DIST)
 		eeems/remarkable-toolchain:$(TOOLCHAIN)-rmppure \
 		bash -exc 'apt-get update; apt-get install -y clang-format;source /opt/codex/tatsu/$(TOOLCHAIN)/environment-setup-cortexa55-remarkable-linux; make FEATURES=$(FEATURES) release'
 
+.PHONY: build-amd64
+build-amd64: BUILDNAME=oxide-amd64
+build-amd64: release
+
 $(DIST):
 	mkdir -p $(DIST)
 

--- a/applications/display-server/connection.cpp
+++ b/applications/display-server/connection.cpp
@@ -581,7 +581,7 @@ Connection::readSocket() {
         );
         do_ack = false;
 #else
-        surface->move(move.header.x, move.header.y);
+        surface->move(move.x, move.y);
 #endif
         break;
       }
@@ -622,7 +622,9 @@ Connection::readSocket() {
           break;
         }
         dbusInterface->removeSurface(surface->id());
+#ifdef EPAPER
         guiThread->notify();
+#endif
         break;
       }
       case Blight::MessageType::List: {

--- a/applications/display-server/dbusinterface.cpp
+++ b/applications/display-server/dbusinterface.cpp
@@ -5,6 +5,7 @@
 #include <liboxide/dbus_types.h>
 #include <liboxide/debug.h>
 #include <liboxide/devicesettings.h>
+#include <liboxide/threading.h>
 #include <memory>
 #include <sys/poll.h>
 #include <unistd.h>
@@ -408,12 +409,19 @@ DbusInterface::frameBuffer(QDBusMessage message) {
     );
     return QDBusUnixFileDescriptor();
   }
+#ifdef EPAPER
   auto frameBuffer = guiThread->framebuffer();
   if (frameBuffer == nullptr) {
     sendErrorReply(QDBusError::InternalError, "Framebuffer is missing");
     return QDBusUnixFileDescriptor();
   }
   return QDBusUnixFileDescriptor(frameBuffer->fd);
+#else
+  sendErrorReply(
+    QDBusError::InternalError, "Framebuffer not supported on this platform"
+  );
+  return QDBusUnixFileDescriptor();
+#endif
 }
 
 FrameBufferInfo
@@ -431,6 +439,7 @@ DbusInterface::frameBufferInfo(QDBusMessage message) {
     );
     return {-1, -1, -1, Blight::Format::Format_Invalid};
   }
+#ifdef EPAPER
   auto frameBuffer = guiThread->framebuffer();
   if (frameBuffer == nullptr) {
     sendErrorReply(QDBusError::InternalError, "Framebuffer is missing");
@@ -442,6 +451,9 @@ DbusInterface::frameBufferInfo(QDBusMessage message) {
     frameBuffer->stride,
     frameBuffer->format
   };
+#else
+  return {1024, 1024, 1024 * 2, Blight::Format::Format_RGB16};
+#endif
 }
 
 void
@@ -850,7 +862,9 @@ DbusInterface::createConnection(int pid) {
         found = connections.contains(connection);
         if (found) {
           connections.removeAll(connection);
+#ifdef EPAPER
           guiThread->notify();
+#endif
         }
       }
       {

--- a/applications/display-server/display-server.pro
+++ b/applications/display-server/display-server.pro
@@ -47,7 +47,11 @@ target.path = $$BIN_INSTALL_PATH
 INSTALLS += target
 
 !system("pkg-config --exists libevdev"): error("Could not find libevdev package via pkg-config")
-LIBS += -Wl,-Bstatic $$system("pkg-config --static --libs libevdev") -Wl,-Bdynamic
+contains(DEFINES,EPAPER){
+    LIBS += -Wl,-Bstatic $$system("pkg-config --static --libs libevdev") -Wl,-Bdynamic
+}else{
+    LIBS += $$system("pkg-config --libs libevdev")
+}
 QMAKE_CXXFLAGS += $$system("pkg-config --cflags libevdev")
 
 HEADERS += \

--- a/applications/display-server/surfacewidget.cpp
+++ b/applications/display-server/surfacewidget.cpp
@@ -34,7 +34,6 @@ QSGNode*
 SurfaceWidget::updatePaintNode(QSGNode* oldNode, UpdatePaintNodeData*) {
   if (!oldNode) {
     oldNode = window()->createImageNode();
-    oldNode->setOwnsTexture(true);
   }
   QRectF rect = boundingRect();
   if (rect.isEmpty()) {

--- a/shared/libblight_client/main.cpp
+++ b/shared/libblight_client/main.cpp
@@ -1,4 +1,5 @@
 #include <asm-generic/fcntl.h>
+#include <csignal>
 #ifdef __aarch64__
 #include "drm.h"
 #endif
@@ -44,10 +45,24 @@ namespace {
 #if defined(__arm__) || defined(__aarch64__) || defined(__x86_64__)
   struct sigaction originalSigsegv{};
   struct sigaction originalSigabrt{};
+  struct sigaction originalSigbus{};
 
   static void
   chain_to_original_handler(int signum, siginfo_t* siginfo, void* context) {
-    auto* action = signum == SIGSEGV ? &originalSigsegv : &originalSigabrt;
+    struct sigaction* action;
+    switch (signum) {
+      case SIGSEGV:
+        action = &originalSigsegv;
+        break;
+      case SIGABRT:
+        action = &originalSigabrt;
+        break;
+      case SIGBUS:
+        action = &originalSigbus;
+        break;
+      default:
+        return;
+    }
     if ((action->sa_flags & SA_SIGINFO) && action->sa_sigaction) {
       action->sa_sigaction(signum, siginfo, context);
     } else if (
@@ -656,11 +671,20 @@ system(const char* command) {
 #if defined(__arm__) || defined(__aarch64__) || defined(__x86_64__)
 __attribute__((visibility("default"))) sighandler_t
 signal(int signum, sighandler_t handler) {
-  if (signum != SIGSEGV && signum != SIGABRT) {
-    return Libc::signal(signum, handler);
+  struct sigaction* originalAction;
+  switch (signum) {
+    case SIGSEGV:
+      originalAction = &originalSigsegv;
+      break;
+    case SIGABRT:
+      originalAction = &originalSigabrt;
+      break;
+    case SIGBUS:
+      originalAction = &originalSigbus;
+      break;
+    default:
+      return Libc::signal(signum, handler);
   }
-  auto* originalAction =
-    signum == SIGSEGV ? &originalSigsegv : &originalSigabrt;
   struct sigaction newAction{};
   newAction.sa_handler = handler;
   auto previousHandler = originalAction->sa_flags & SA_SIGINFO
@@ -683,8 +707,13 @@ sigaction(
   const struct sigaction* newAction,
   struct sigaction* oldAction
 ) {
-  if (signum != SIGSEGV && signum != SIGABRT) {
-    return Libc::sigaction(signum, newAction, oldAction);
+  switch (signum) {
+    case SIGSEGV:
+    case SIGABRT:
+    case SIGBUS:
+      break;
+    default:
+      return Libc::sigaction(signum, newAction, oldAction);
   }
   if (oldAction != nullptr) {
     int result = Libc::sigaction(signum, nullptr, oldAction);
@@ -695,7 +724,17 @@ sigaction(
   if (newAction == nullptr) {
     return 0;
   }
-  *(signum == SIGSEGV ? &originalSigsegv : &originalSigabrt) = *newAction;
+  switch (signum) {
+    case SIGSEGV:
+      originalSigsegv = *newAction;
+      break;
+    case SIGABRT:
+      originalSigabrt = *newAction;
+      break;
+    case SIGBUS:
+      originalSigbus = *newAction;
+      break;
+  }
   struct sigaction action{};
   action.sa_sigaction = __signal_handler;
   action.sa_flags = SA_SIGINFO;
@@ -707,6 +746,7 @@ sigaction(
 
 void __attribute__((constructor)) static init(void) {
 #ifdef DEBUG
+#if defined(__arm__) || defined(__aarch64__) || defined(__x86_64__)
   struct sigaction intercept_sigaction{};
   intercept_sigaction.sa_flags = SA_SIGINFO;
   intercept_sigaction.sa_sigaction = __signal_handler;
@@ -715,6 +755,7 @@ void __attribute__((constructor)) static init(void) {
   Libc::sigaction(SIGABRT, &intercept_sigaction, NULL);
   intercept_sigaction.sa_sigaction = __signal_handler;
   Libc::sigaction(SIGBUS, &intercept_sigaction, NULL);
+#endif
 #endif
   if (Client::init() && FB::init() && Input::init()) {
     Client::FAILED_INIT = false;

--- a/shared/libblight_client/main.cpp
+++ b/shared/libblight_client/main.cpp
@@ -41,6 +41,7 @@
 
 namespace {
 #ifdef DEBUG
+#if defined(__arm__) || defined(__aarch64__) || defined(__x86_64__)
   struct sigaction originalSigsegv{};
   struct sigaction originalSigabrt{};
 
@@ -72,6 +73,8 @@ namespace {
       reinterpret_cast<void*>(uc->uc_mcontext.arm_pc);
 #elif defined(__aarch64__)
       reinterpret_cast<void*>(uc->uc_mcontext.pc);
+#elif defined(__x86_64__)
+      (void*)uc->uc_mcontext.gregs[REG_RIP];
 #endif
     constexpr int depth = 50;
     void* array[depth];
@@ -90,6 +93,7 @@ namespace {
         _Exit(1);
     }
   }
+#endif
 #endif
 
   int __open(const char* pathname, int flags) {
@@ -653,6 +657,7 @@ system(const char* command) {
 }
 
 #ifdef DEBUG
+#if defined(__arm__) || defined(__aarch64__) || defined(__x86_64__)
 __attribute__((visibility("default"))) sighandler_t
 signal(int signum, sighandler_t handler) {
   if (signum != SIGSEGV && signum != SIGABRT) {
@@ -701,6 +706,7 @@ sigaction(
   sigemptyset(&action.sa_mask);
   return Libc::sigaction(signum, &action, nullptr);
 }
+#endif
 #endif
 
 void __attribute__((constructor)) static init(void) {

--- a/shared/libblight_client/main.cpp
+++ b/shared/libblight_client/main.cpp
@@ -79,19 +79,15 @@ namespace {
     constexpr int depth = 50;
     void* array[depth];
     size_t size = backtrace(array, depth);
-    array[1] = caller_address;
-    backtrace_symbols_fd(array + 1, size - 1, STDERR_FILENO);
-    chain_to_original_handler(signal, siginfo, context);
-    switch (signal) {
-      case SIGSEGV:
-        _Exit(139);
-      case SIGABRT:
-        _Exit(134);
-      case SIGBUS:
-        _Exit(138);
-      default:
-        _Exit(1);
+    if (size > 1) {
+      array[1] = caller_address;
+      backtrace_symbols_fd(array + 1, size - 1, STDERR_FILENO);
+    } else {
+      const char* msg2 = "Unable to get backtrace\n";
+      ::write(STDERR_FILENO, msg2, std::strlen(msg2));
     }
+    chain_to_original_handler(signal, siginfo, context);
+    _Exit(128 + signal);
   }
 #endif
 #endif

--- a/shared/libblight_protocol/libblight_protocol.h
+++ b/shared/libblight_protocol/libblight_protocol.h
@@ -5,6 +5,7 @@
  */
 #pragma once
 
+#include <linux/input.h>
 #include <linux/types.h>
 #include <systemd/sd-bus.h>
 

--- a/shared/liboxide/devicesettings.cpp
+++ b/shared/liboxide/devicesettings.cpp
@@ -333,7 +333,11 @@ namespace Oxide {
       case DeviceType::RMPPM:
         return 954;
       default:
+#ifdef EPAPER
         return 0;
+#else
+        return 1024;
+#endif
     }
   }
 
@@ -348,7 +352,11 @@ namespace Oxide {
       case DeviceType::RMPPM:
         return 1696;
       default:
+#ifdef EPAPER
         return 0;
+#else
+        return 1024;
+#endif
     }
   }
 

--- a/shared/liboxide/signalhandler.cpp
+++ b/shared/liboxide/signalhandler.cpp
@@ -90,6 +90,7 @@ namespace Oxide {
   }
   void SignalHandler::handleSignal(int signal, siginfo_t* si, void* vcontext) {
     Q_UNUSED(si);
+#if defined(__arm__) || defined(__aarch64__)
     if (signal == SIGPIPE || signal == SIGSEGV || signal == SIGBUS) {
       constexpr int depth = 10;
       auto uc = (ucontext_t*)vcontext;
@@ -98,8 +99,6 @@ namespace Oxide {
         (void*)uc->uc_mcontext.arm_pc;
 #elif defined(__aarch64__)
         (void*)uc->uc_mcontext.pc;
-#else
-#error "Unsupported architecture"
 #endif
       void* array[depth];
       size_t size = ::backtrace(array, depth);
@@ -109,6 +108,7 @@ namespace Oxide {
       ::write(STDERR_FILENO, "\n", std::strlen("\n"));
       ::backtrace_symbols_fd(array + 1, size - 1, STDERR_FILENO);
     }
+#endif
     if (!hasNotifier(signal)) {
       ::signal(signal, SIG_DFL);
       ::raise(signal);

--- a/shared/liboxide/signalhandler.cpp
+++ b/shared/liboxide/signalhandler.cpp
@@ -104,11 +104,16 @@ namespace Oxide {
 #endif
       void* array[depth];
       size_t size = ::backtrace(array, depth);
-      array[1] = caller_address;
       const char* msg = strsignal(signal);
       ::write(STDERR_FILENO, msg, std::strlen(msg));
       ::write(STDERR_FILENO, "\n", std::strlen("\n"));
-      ::backtrace_symbols_fd(array + 1, size - 1, STDERR_FILENO);
+      if (size > 1) {
+        array[1] = caller_address;
+        ::backtrace_symbols_fd(array + 1, size - 1, STDERR_FILENO);
+      } else {
+        const char* msg2 = "Unable to get backtrace\n";
+        ::write(STDERR_FILENO, msg2, std::strlen(msg2));
+      }
     }
 #endif
     if (!hasNotifier(signal)) {

--- a/shared/liboxide/signalhandler.cpp
+++ b/shared/liboxide/signalhandler.cpp
@@ -90,7 +90,7 @@ namespace Oxide {
   }
   void SignalHandler::handleSignal(int signal, siginfo_t* si, void* vcontext) {
     Q_UNUSED(si);
-#if defined(__arm__) || defined(__aarch64__)
+#if defined(__arm__) || defined(__aarch64__) || defined(__x86_64__)
     if (signal == SIGPIPE || signal == SIGSEGV || signal == SIGBUS) {
       constexpr int depth = 10;
       auto uc = (ucontext_t*)vcontext;
@@ -99,6 +99,8 @@ namespace Oxide {
         (void*)uc->uc_mcontext.arm_pc;
 #elif defined(__aarch64__)
         (void*)uc->uc_mcontext.pc;
+#elif defined(__x86_64__)
+        (void*)uc->uc_mcontext.gregs[REG_RIP];
 #endif
       void* array[depth];
       size_t size = ::backtrace(array, depth);

--- a/shared/lockscreen_hook/lockscreen_hook.pro
+++ b/shared/lockscreen_hook/lockscreen_hook.pro
@@ -1,3 +1,6 @@
+!linux-oe-g++{
+    error("epaper is only supported on the reMarkable")
+}
 TARGET = lockscreen_hook
 TEMPLATE = lib
 

--- a/shared/lockscreen_hook/main.cpp
+++ b/shared/lockscreen_hook/main.cpp
@@ -41,6 +41,9 @@ __signal_handler(int signal, siginfo_t* si, void* vcontext) {
     reinterpret_cast<void*>(uc->uc_mcontext.arm_pc);
 #elif defined(__aarch64__)
     reinterpret_cast<void*>(uc->uc_mcontext.pc);
+#else
+    nullptr;
+  _Exit(128 + signal);
 #endif
   void* array[depth];
   size_t size = backtrace(array, depth);
@@ -49,16 +52,7 @@ __signal_handler(int signal, siginfo_t* si, void* vcontext) {
   ::write(STDERR_FILENO, msg, std::strlen(msg));
   ::write(STDERR_FILENO, "\n", std::strlen("\n"));
   backtrace_symbols_fd(array + 1, size - 1, STDERR_FILENO);
-  switch (signal) {
-    case SIGSEGV:
-      _Exit(139);
-    case SIGABRT:
-      _Exit(134);
-    case SIGBUS:
-      _Exit(138);
-    default:
-      _Exit(1);
-  }
+  _Exit(128 + signal);
 }
 
 #endif

--- a/shared/lockscreen_hook/main.cpp
+++ b/shared/lockscreen_hook/main.cpp
@@ -30,7 +30,7 @@
 #endif
 
 #ifdef DEBUG
-
+#if defined(__arm__) || defined(__aarch64__) || defined(__x86_64__)
 void
 __signal_handler(int signal, siginfo_t* si, void* vcontext) {
   Q_UNUSED(si);
@@ -61,7 +61,7 @@ __signal_handler(int signal, siginfo_t* si, void* vcontext) {
   }
   _Exit(128 + signal);
 }
-
+#endif
 #endif
 
 static std::atomic<bool> enabled = false;
@@ -237,6 +237,7 @@ _ZN6QImageC2ERK7QStringPKc(
 void __attribute__((constructor))
 init(void) {
 #ifdef DEBUG
+#if defined(__arm__) || defined(__aarch64__) || defined(__x86_64__)
   QLoggingCategory::setFilterRules("lockscreen_hook=true");
   struct sigaction action{};
   action.sa_flags = SA_SIGINFO;
@@ -246,6 +247,7 @@ init(void) {
   sigaction(SIGABRT, &action, nullptr);
   action.sa_sigaction = __signal_handler;
   sigaction(SIGBUS, &action, nullptr);
+#endif
 #endif
   enabled = true;
 }

--- a/shared/lockscreen_hook/main.cpp
+++ b/shared/lockscreen_hook/main.cpp
@@ -41,17 +41,24 @@ __signal_handler(int signal, siginfo_t* si, void* vcontext) {
     reinterpret_cast<void*>(uc->uc_mcontext.arm_pc);
 #elif defined(__aarch64__)
     reinterpret_cast<void*>(uc->uc_mcontext.pc);
+#elif defined(__x86_64__)
+    (void*)uc->uc_mcontext.gregs[REG_RIP];
 #else
     nullptr;
   _Exit(128 + signal);
 #endif
   void* array[depth];
   size_t size = backtrace(array, depth);
-  array[1] = caller_address;
   const char* msg = strsignal(signal);
   ::write(STDERR_FILENO, msg, std::strlen(msg));
   ::write(STDERR_FILENO, "\n", std::strlen("\n"));
-  backtrace_symbols_fd(array + 1, size - 1, STDERR_FILENO);
+  if (size > 1) {
+    array[1] = caller_address;
+    backtrace_symbols_fd(array + 1, size - 1, STDERR_FILENO);
+  } else {
+    const char* msg2 = "Unable to get backtrace\n";
+    ::write(STDERR_FILENO, msg2, std::strlen(msg2));
+  }
   _Exit(128 + signal);
 }
 

--- a/shared/qpa/default_keymap.h
+++ b/shared/qpa/default_keymap.h
@@ -79,7 +79,7 @@ enum Modifiers {
   ModMeta = 0x100,
 };
 
-const QEvdevKeyboardMap::Mapping OxideEventHandler::s_keymap_default[] = {
+const KeyboardMap::Mapping OxideEventHandler::s_keymap_default[] = {
   {KEY_ESC,         0xffff, 0x01000000,                   0x00, Flags::None,       0x0000           },
   {KEY_1,           0x0031, 0x00000031,                   0x00, Flags::None,       0x0000           },
   {KEY_1,           0x0021, 0x00000021,                   0x01, Flags::None,       0x0000           },
@@ -725,7 +725,7 @@ const QEvdevKeyboardMap::Mapping OxideEventHandler::s_keymap_default[] = {
   {KEY_CHANNELDOWN, 0xffff, Qt::Key_ChannelDown,          0x00, Flags::None,       0x0000           },
 };
 
-const QEvdevKeyboardMap::Composing OxideEventHandler::s_keycompose_default[] = {
+const KeyboardMap::Composing OxideEventHandler::s_keycompose_default[] = {
   {0x0060, 0x0041, 0x00c0},
   {0x0060, 0x0061, 0x00e0},
   {0x0027, 0x0041, 0x00c1},

--- a/shared/qpa/oxideeventhandler.cpp
+++ b/shared/qpa/oxideeventhandler.cpp
@@ -3,8 +3,10 @@
 #include <libblight.h>
 #include <liboxide/debug.h>
 #include <liboxide/devicesettings.h>
-#include <private/qevdevtouchfilter_p.h>
 #include <private/qhighdpiscaling_p.h>
+#if defined(__arm__) || defined(__aarch64__)
+#include <private/qevdevtouchfilter_p.h>
+#endif
 
 #include <QFile>
 
@@ -384,12 +386,12 @@ OxideEventHandler::processKeyboardEvent(
   bool pressed = event->value;
   bool autorepeat = event->value == 2;
   bool first_press = pressed && !autorepeat;
-  const QEvdevKeyboardMap::Mapping* map_plain = 0;
-  const QEvdevKeyboardMap::Mapping* map_withmod = 0;
+  const KeyboardMap::Mapping* map_plain = 0;
+  const KeyboardMap::Mapping* map_withmod = 0;
   quint8 modifiers = keyboardData->m_modifiers;
 
   for (int i = 0; i < m_keymap_size && !(map_plain && map_withmod); ++i) {
-    const QEvdevKeyboardMap::Mapping* m = m_keymap + i;
+    const KeyboardMap::Mapping* m = m_keymap + i;
     if (m->keycode == keycode) {
       if (m->modifiers == 0) {
         map_plain = m;
@@ -397,9 +399,9 @@ OxideEventHandler::processKeyboardEvent(
       quint8 testmods = keyboardData->m_modifiers;
       if (
         keyboardData->m_locks[0] /*CapsLock*/
-        && (m->flags & QEvdevKeyboardMap::IsLetter)
+        && (m->flags & KeyboardMap::IsLetter)
       ) {
-        testmods ^= QEvdevKeyboardMap::ModShift;
+        testmods ^= KeyboardMap::ModShift;
       }
       if (m->modifiers == testmods) {
         map_withmod = m;
@@ -409,11 +411,11 @@ OxideEventHandler::processKeyboardEvent(
 
   if (
     keyboardData->m_locks[0] /*CapsLock*/
-    && map_withmod && (map_withmod->flags & QEvdevKeyboardMap::IsLetter)
+    && map_withmod && (map_withmod->flags & KeyboardMap::IsLetter)
   ) {
-    modifiers ^= QEvdevKeyboardMap::ModShift;
+    modifiers ^= KeyboardMap::ModShift;
   }
-  const QEvdevKeyboardMap::Mapping* it = map_withmod ? map_withmod : map_plain;
+  const KeyboardMap::Mapping* it = map_withmod ? map_withmod : map_plain;
   // we couldn't even find a plain mapping
   if (!it) {
     O_WARNING("No mapping for keycode found:" << keycode);
@@ -421,7 +423,7 @@ OxideEventHandler::processKeyboardEvent(
   }
   quint16 unicode = it->unicode;
   quint32 qtcode = it->qtcode;
-  if (it->flags & QEvdevKeyboardMap::IsModifier && it->special) {
+  if (it->flags & KeyboardMap::IsModifier && it->special) {
     // this is a modifier, i.e. Shift, Alt, ...
     if (pressed) {
       keyboardData->m_modifiers |= it->special;
@@ -435,10 +437,10 @@ OxideEventHandler::processKeyboardEvent(
       lock ^= 1;
     }
   } else if (
-    (it->flags & QEvdevKeyboardMap::IsSystem) && it->special && first_press
+    (it->flags & KeyboardMap::IsSystem) && it->special && first_press
   ) {
     switch (it->special) {
-      case QEvdevKeyboardMap::SystemZap:
+      case KeyboardMap::SystemZap:
         if (!m_no_zap) {
           qApp->quit();
         }
@@ -451,7 +453,7 @@ OxideEventHandler::processKeyboardEvent(
       keyboardData->m_composing = 2;
     }
     return;
-  } else if (it->flags & QEvdevKeyboardMap::IsDead && m_do_compose) {
+  } else if (it->flags & KeyboardMap::IsDead && m_do_compose) {
     // a Dead key was pressed twice
     if (
       first_press && keyboardData->m_composing == 1 &&
@@ -482,7 +484,7 @@ OxideEventHandler::processKeyboardEvent(
   }
   if (
     keyboardData->m_composing == 2 && first_press &&
-    !(it->flags & QEvdevKeyboardMap::IsModifier)
+    !(it->flags & KeyboardMap::IsModifier)
   ) {
     // the last key press was the Compose key
     if (unicode != 0xffff) {
@@ -507,7 +509,7 @@ OxideEventHandler::processKeyboardEvent(
     }
   } else if (
     keyboardData->m_composing == 1 && first_press &&
-    !(it->flags & QEvdevKeyboardMap::IsModifier)
+    !(it->flags & KeyboardMap::IsModifier)
   ) {
     // the last key press was a Dead key
     bool valid = false;
@@ -1162,19 +1164,16 @@ OxideEventHandler::loadKeymap(const QString& file) {
   QDataStream ds(&f);
   ds >> qmap_magic >> qmap_version >> qmap_keymap_size >> qmap_keycompose_size;
   if (
-    ds.status() != QDataStream::Ok ||
-    qmap_magic != QEvdevKeyboardMap::FileMagic || qmap_version != 1 ||
-    qmap_keymap_size == 0
+    ds.status() != QDataStream::Ok || qmap_magic != KeyboardMap::FileMagic ||
+    qmap_version != 1 || qmap_keymap_size == 0
   ) {
     O_WARNING(qUtf16Printable(file) << " is not a valid .qmap keymap file");
     return false;
   }
-  QEvdevKeyboardMap::Mapping* qmap_keymap =
-    new QEvdevKeyboardMap::Mapping[qmap_keymap_size];
-  QEvdevKeyboardMap::Composing* qmap_keycompose =
-    qmap_keycompose_size
-      ? new QEvdevKeyboardMap::Composing[qmap_keycompose_size]
-      : 0;
+  KeyboardMap::Mapping* qmap_keymap =
+    new KeyboardMap::Mapping[qmap_keymap_size];
+  KeyboardMap::Composing* qmap_keycompose =
+    qmap_keycompose_size ? new KeyboardMap::Composing[qmap_keycompose_size] : 0;
   for (quint32 i = 0; i < qmap_keymap_size; ++i) {
     ds >> qmap_keymap[i];
   }

--- a/shared/qpa/oxideeventhandler.h
+++ b/shared/qpa/oxideeventhandler.h
@@ -19,6 +19,12 @@
 #include <thread>
 #include <vector>
 
+#if defined(__arm__) || defined(__aarch64__)
+namespace KeyboardMap = QEvdevKeyboardMap;
+#else
+namespace KeyboardMap = QKeyboardMap;
+#endif
+
 class OxideEventManager;
 
 class DeviceData : public std::enable_shared_from_this<DeviceData> {
@@ -79,16 +85,16 @@ private:
 
   OxideEventManager* m_manager;
   QMap<unsigned int, std::shared_ptr<DeviceData>> m_devices;
-  const QEvdevKeyboardMap::Mapping* m_keymap;
+  const KeyboardMap::Mapping* m_keymap;
   int m_keymap_size;
-  const QEvdevKeyboardMap::Composing* m_keycompose;
+  const KeyboardMap::Composing* m_keycompose;
   int m_keycompose_size;
   bool m_no_zap;
   bool m_do_compose;
   QTransform m_rotate;
 
-  static const QEvdevKeyboardMap::Mapping s_keymap_default[];
-  static const QEvdevKeyboardMap::Composing s_keycompose_default[];
+  static const KeyboardMap::Mapping s_keymap_default[];
+  static const KeyboardMap::Composing s_keycompose_default[];
   static Qt::KeyboardModifiers toQtModifiers(quint16 mod);
 
   void unloadKeymap();

--- a/shared/shared.pro
+++ b/shared/shared.pro
@@ -1,24 +1,25 @@
 TEMPLATE = subdirs
 
 SUBDIRS = \
-    liboxide \
-    libblight_protocol \
-    libblight \
-    libblight_client \
-    qpa \
-    lockscreen_hook \
     cpptrace \
+    libblight \
+    libblight_protocol \
+    liboxide \
+    qpa \
     sentry
 
 liboxide.depends = \
-    libblight \
     cpptrace \
+    libblight \
     sentry
 libblight.depends = libblight_protocol
-libblight_client.depends = libblight
 qpa.depends = libblight liboxide
 linux-oe-g++{
-    SUBDIRS += epaper
+    SUBDIRS += \
+        epaper \
+        libblight_client \
+        lockscreen_hook
     liboxide.depends += epaper
+    libblight_client.depends = libblight
 }
 INSTALLS += $$SUBDIRS

--- a/tests/libblight_protocol/test.c
+++ b/tests/libblight_protocol/test.c
@@ -1,6 +1,5 @@
 #include <assert.h>
 #include <errno.h>
-#include <libblight_protocol.h>
 #include <libblight_protocol/socket.h>
 #include <linux/input.h>
 #include <pthread.h>
@@ -13,6 +12,8 @@
 #include <sys/time.h>
 #include <sys/un.h>
 #include <unistd.h>
+
+#include "test.h"
 
 #define __RIGHT_HERE__                                                         \
   fprintf(stderr, "<============================ %s:%d\n", __FILE__, __LINE__)

--- a/tests/libblight_protocol/test.h
+++ b/tests/libblight_protocol/test.h
@@ -2,8 +2,8 @@
 
 #include <libblight_protocol.h>
 
-extern "C" {
 #ifdef __cplusplus
+extern "C" {
 BlightProtocol::blight_input_buffer_t*
 #else
 blight_input_buffer_t*
@@ -11,4 +11,6 @@ blight_input_buffer_t*
 create_test_input_buffer();
 int
 test_c();
+#ifdef __cplusplus
 }
+#endif


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated amd64 build target for x86_64 release builds.
* **Bug Fixes**
  * Improved EPAPER move destination behavior and tightened EPAPER-only framebuffer/notification support.
  * Enhanced crash/backtrace signal handling on supported architectures with safer termination.
  * Refined keyboard mapping behavior across architectures and corrected initial surface texture ownership handling.
* **Build / Chores**
  * Added platform/toolchain checks, conditional libevdev linking, and updated shared build wiring to match supported environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->