### PR TITLE
Suspend on lid close, allow overriding system and notification overlays

### DIFF
--- a/applications/system-service/controller.h
+++ b/applications/system-service/controller.h
@@ -3,6 +3,9 @@
 #include <liboxide/oxideqml.h>
 
 #include <QObject>
+#include <QSocketNotifier>
+
+#include <fcntl.h>
 
 #include "appsapi.h"
 #include "screenapi.h"
@@ -102,6 +105,15 @@ public:
   int upSwipeLength() { return systemAPI->getSwipeLength(SystemAPI::Up); }
   int downSwipeLength() { return systemAPI->getSwipeLength(SystemAPI::Down); }
 
+  ~Controller() {
+    for (auto& monitor : m_switchMonitors) {
+      delete monitor.notifier;
+      if (monitor.fd >= 0) {
+        ::close(monitor.fd);
+      }
+    }
+  }
+
 signals:
   void keyPressed(int, int, const QString&);
   void keyReleased(int, int, const QString&);
@@ -113,8 +125,69 @@ signals:
   void rightSwipeLengthChanged(int);
   void upSwipeLengthChanged(int);
   void downSwipeLengthChanged(int);
+  void lidClosed();
+  void lidOpened();
+  void penAttached();
+  void penDetached();
 
 private:
+  struct SwitchMonitor {
+    int fd = -1;
+    QSocketNotifier* notifier = nullptr;
+  };
+  QList<SwitchMonitor> m_switchMonitors;
+
+  void readEvents() {
+    auto notifier = qobject_cast<QSocketNotifier*>(sender());
+    if (notifier == nullptr) {
+      return;
+    }
+    int fd = notifier->socket();
+    struct input_event ev;
+    while (::read(fd, &ev, sizeof(ev)) == sizeof(ev)) {
+      if (ev.type != EV_SW) {
+        continue;
+      }
+      switch (ev.code) {
+        case SW_LID:
+          if (ev.value) {
+            emit lidClosed();
+          } else {
+            emit lidOpened();
+          }
+          break;
+        case SW_PEN_INSERTED:
+          if (ev.value) {
+            emit penAttached();
+          } else {
+            emit penDetached();
+          }
+          break;
+      }
+    }
+  }
+
+  void inputDevicesChanged() {
+    for (auto& monitor : m_switchMonitors) {
+      delete monitor.notifier;
+      if (monitor.fd >= 0) {
+        ::close(monitor.fd);
+      }
+    }
+    m_switchMonitors.clear();
+    for (auto& sw : deviceSettings.switches()) {
+      int fd = ::open(sw.device.c_str(), O_RDONLY | O_NONBLOCK);
+      if (fd < 0) {
+        continue;
+      }
+      auto notifier = new QSocketNotifier(fd, QSocketNotifier::Read, this);
+      connect(
+        notifier, &QSocketNotifier::activated, this, &Controller::readEvents
+      );
+      m_switchMonitors.append({fd, notifier});
+    }
+  }
+
   explicit Controller(QObject* parent = nullptr)
     : QObject(parent) {
     connect(
@@ -188,5 +261,7 @@ private:
       }
       return false;
     });
+    inputDevicesChanged();
+    deviceSettings.onInputDevicesChanged([this] { inputDevicesChanged(); });
   }
 };

--- a/applications/system-service/controller.h
+++ b/applications/system-service/controller.h
@@ -1,13 +1,22 @@
 #pragma once
 
-#include <liboxide/oxideqml.h>
+#include <liboxide/debug.h>
+#include <liboxide/devicesettings.h>
 
+#include <QKeyEvent>
+#include <QList>
 #include <QObject>
 #include <QSocketNotifier>
 
+#include <cerrno>
 #include <fcntl.h>
+#include <linux/input-event-codes.h>
+#include <linux/input.h>
+#include <unistd.h>
 
+#include "application.h"
 #include "appsapi.h"
+#include "eventlistener.h"
 #include "screenapi.h"
 #include "systemapi.h"
 
@@ -144,26 +153,66 @@ private:
     }
     int fd = notifier->socket();
     struct input_event ev;
-    while (::read(fd, &ev, sizeof(ev)) == sizeof(ev)) {
-      if (ev.type != EV_SW) {
+    int lidState = -1;
+    int penState = -1;
+    while (true) {
+      auto res = ::read(fd, &ev, sizeof(ev));
+      if (res == -1) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK) {
+          break;
+        }
+        O_WARNING("Failed reading event device, disabling it");
+        for (int i = 0; i < m_switchMonitors.size(); i++) {
+          auto& monitor = m_switchMonitors[i];
+          if (monitor.fd != fd) {
+            continue;
+          }
+          monitor.notifier->setEnabled(false);
+          monitor.notifier->deleteLater();
+          ::close(m_switchMonitors[i].fd);
+          m_switchMonitors.removeAt(i);
+          break;
+        }
+        return;
+      }
+      if (res != sizeof(ev)) {
+        break;
+      }
+      if (ev.type == EV_SW) {
+        switch (ev.code) {
+          case SW_LID:
+            lidState = ev.value;
+            break;
+          case SW_PEN_INSERTED:
+            penState = ev.value;
+            break;
+        }
         continue;
       }
-      switch (ev.code) {
-        case SW_LID:
-          if (ev.value) {
-            emit lidClosed();
-          } else {
-            emit lidOpened();
-          }
-          break;
-        case SW_PEN_INSERTED:
-          if (ev.value) {
-            emit penAttached();
-          } else {
-            emit penDetached();
-          }
-          break;
+      if (ev.type != EV_SYN) {
+        continue;
       }
+      if (ev.code == SYN_DROPPED) {
+        lidState = -1;
+        penState = -1;
+        continue;
+      }
+      if (lidState != -1) {
+        if (lidState) {
+          emit lidClosed();
+        } else {
+          emit lidOpened();
+        }
+      }
+      if (penState != -1) {
+        if (penState) {
+          emit penAttached();
+        } else {
+          emit penDetached();
+        }
+      }
+      lidState = -1;
+      penState = -1;
     }
   }
 

--- a/applications/system-service/main.cpp
+++ b/applications/system-service/main.cpp
@@ -230,11 +230,11 @@ main(int argc, char* argv[]) {
   QUrl overlayUrl(sharedSettings.systemOverlay());
   engine.load(overlayUrl);
   if (engine.rootObjects().isEmpty()) {
-    qWarning() << "Failed to load system overlay:" << overlayUrl
-               << "- falling back to qrc:/main.qml";
+    O_WARNING("Failed to load system overlay:" << overlayUrl);
     engine.load(QUrl(QStringLiteral("qrc:/main.qml")));
     if (engine.rootObjects().isEmpty()) {
-      qFatal("Failed to load main layout");
+      qWarning("Failed to load main layout");
+      return EXIT_FAILURE;
     }
   }
   QTimer::singleShot(0, [&engine, &buffer] {

--- a/applications/system-service/main.cpp
+++ b/applications/system-service/main.cpp
@@ -227,9 +227,15 @@ main(int argc, char* argv[]) {
   registerQML(&engine);
   QQmlContext* context = engine.rootContext();
   context->setContextProperty("controller", Controller::singleton());
-  engine.load(QUrl(QStringLiteral("qrc:/main.qml")));
+  QUrl overlayUrl(sharedSettings.systemOverlay());
+  engine.load(overlayUrl);
   if (engine.rootObjects().isEmpty()) {
-    qFatal("Failed to load main layout");
+    qWarning() << "Failed to load system overlay:" << overlayUrl
+               << "- falling back to qrc:/main.qml";
+    engine.load(QUrl(QStringLiteral("qrc:/main.qml")));
+    if (engine.rootObjects().isEmpty()) {
+      qFatal("Failed to load main layout");
+    }
   }
   QTimer::singleShot(0, [&engine, &buffer] {
     dbusService->startup(&engine);

--- a/applications/system-service/main.qml
+++ b/applications/system-service/main.qml
@@ -64,6 +64,12 @@ Window{
             }
         }
     }
+    Connections{
+        target: controller
+        function onLidClosed(){
+            controller.suspend()
+        }
+    }
     Timer{
         id: leftHeldTimer
         running: false

--- a/applications/system-service/notificationapi.cpp
+++ b/applications/system-service/notificationapi.cpp
@@ -61,7 +61,13 @@ NotificationAPI::setEnabled(bool enabled) {
 void
 NotificationAPI::startup() {
   auto engine = dbusService->engine();
-  engine->load("qrc:/notification.qml");
+  QUrl overlayUrl(sharedSettings.notificationOverlay());
+  engine->load(overlayUrl);
+  if (engine->rootObjects().isEmpty()) {
+    qWarning() << "Failed to load notification overlay:" << overlayUrl
+               << "- falling back to qrc:/notification.qml";
+    engine->load(QUrl(QStringLiteral("qrc:/notification.qml")));
+  }
   m_window = static_cast<QQuickWindow*>(engine->rootObjects().last());
   auto buffer = Oxide::QML::getSurfaceForWindow(m_window);
   getCompositorDBus()->setFlags(

--- a/applications/system-service/notificationapi.cpp
+++ b/applications/system-service/notificationapi.cpp
@@ -63,10 +63,12 @@ NotificationAPI::startup() {
   auto engine = dbusService->engine();
   QUrl overlayUrl(sharedSettings.notificationOverlay());
   engine->load(overlayUrl);
-  if (engine->rootObjects().isEmpty()) {
-    qWarning() << "Failed to load notification overlay:" << overlayUrl
-               << "- falling back to qrc:/notification.qml";
+  if (engine->rootObjects().count() < 2) {
+    O_WARNING("Failed to load notification overlay:" << overlayUrl);
     engine->load(QUrl(QStringLiteral("qrc:/notification.qml")));
+    if (engine->rootObjects().count() < 2) {
+      qFatal("Failed to load notification overlay");
+    }
   }
   m_window = static_cast<QQuickWindow*>(engine->rootObjects().last());
   auto buffer = Oxide::QML::getSurfaceForWindow(m_window);

--- a/shared/liboxide/devicesettings.cpp
+++ b/shared/liboxide/devicesettings.cpp
@@ -1,5 +1,6 @@
 #include "devicesettings.h"
 
+#include <linux/input-event-codes.h>
 #include <mutex>
 #include <private/qguiapplication_p.h>
 #include <private/qinputdevicemanager_p.h>
@@ -499,6 +500,42 @@ namespace Oxide {
         callback();
       }
     );
+  }
+
+  QList<event_device> DeviceSettings::switches() {
+    QList<event_device> switches;
+    for (auto device : inputDevices()) {
+      if (
+        device.device == buttonsPath || device.device == wacomPath ||
+        device.device == touchPath
+      ) {
+        continue;
+      }
+      int fd = device.fd;
+      unsigned long bit[EV_MAX];
+      ioctl(fd, EVIOCGBIT(0, EV_MAX), bit);
+      if (!test_bit(EV_SW, bit)) {
+        continue;
+      }
+      if (
+        !checkBitSet(fd, EV_SW, SW_LID) ||
+        !checkBitSet(fd, EV_SW, SW_PEN_INSERTED)
+      ) {
+        continue;
+      }
+      auto name = QFileInfo(device.device.c_str()).baseName();
+      SysObject sys("/sys/class/input/" + name + "/device");
+      auto vendor = sys.strProperty("id/vendor");
+      if (vendor == "0000") {
+        continue;
+      }
+      auto product = sys.strProperty("id/product");
+      if (product == "0000") {
+        continue;
+      }
+      switches.append(device);
+    }
+    return switches;
   }
 
   QList<event_device> DeviceSettings::keyboards() {

--- a/shared/liboxide/devicesettings.h
+++ b/shared/liboxide/devicesettings.h
@@ -196,6 +196,11 @@ namespace Oxide {
      */
     void onInputDevicesChanged(std::function<void()> callback);
     /*!
+     * \brief Get the list of all switches evdev devices
+     * \return All switches devices
+     */
+    QList<event_device> switches();
+    /*!
      * \brief Get the list of all keyboard evdev devices
      * \return All keyboard devices
      */

--- a/shared/liboxide/sharedsettings.cpp
+++ b/shared/liboxide/sharedsettings.cpp
@@ -26,4 +26,18 @@ namespace Oxide {
   O_SETTINGS_PROPERTY_BODY(SharedSettings, QString, Lockscreen, pin)
   O_SETTINGS_PROPERTY_BODY(SharedSettings, QString, Lockscreen, onLogin)
   O_SETTINGS_PROPERTY_BODY(SharedSettings, QString, Lockscreen, onFailedLogin)
+  O_SETTINGS_PROPERTY_BODY(
+    SharedSettings,
+    QString,
+    General,
+    systemOverlay,
+    "qrc:/main.qml"
+  )
+  O_SETTINGS_PROPERTY_BODY(
+    SharedSettings,
+    QString,
+    General,
+    notificationOverlay,
+    "qrc:/notification.qml"
+  )
 } // namespace Oxide

--- a/shared/liboxide/sharedsettings.h
+++ b/shared/liboxide/sharedsettings.h
@@ -219,6 +219,42 @@ namespace Oxide {
      * \brief If the lockscreen onFailedLogin has been changed
      */
     O_SETTINGS_PROPERTY(QString, Lockscreen, onFailedLogin)
+    /*!
+     * \property systemOverlay
+     * \brief The QML file used for the system overlay (gestures, keyboard
+     * shortcuts, etc)
+     * \sa set_systemOverlay, systemOverlayChanged
+     */
+    /*!
+     * \fn set_systemOverlay
+     * \param _arg_systemOverlay
+     * \brief Change the system overlay QML file
+     */
+    /*!
+     * \fn systemOverlayChanged
+     * \brief If the system overlay QML file has been changed
+     */
+    O_SETTINGS_PROPERTY(QString, General, systemOverlay, "qrc:/main.qml")
+    /*!
+     * \property notificationOverlay
+     * \brief The QML file used for the notification overlay
+     * \sa set_notificationOverlay, notificationOverlayChanged
+     */
+    /*!
+     * \fn set_notificationOverlay
+     * \param _arg_notificationOverlay
+     * \brief Change the notification overlay QML file
+     */
+    /*!
+     * \fn notificationOverlayChanged
+     * \brief If the notification overlay QML file has been changed
+     */
+    O_SETTINGS_PROPERTY(
+      QString,
+      General,
+      notificationOverlay,
+      "qrc:/notification.qml"
+    )
 
   private:
     ~SharedSettings();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added monitoring for lid and pen switch events, emitting open/close and attach/detach changes.
  * Added detection for compatible switch-capable input devices to drive these events.
  * Made the system UI and notification UI overlays configurable via settings (with defaults preserved).

* **Bug Fixes**
  * Improved overlay loading: if a custom overlay fails, the app falls back to the built-in default instead of immediately stopping.
  * Closing the lid now triggers system suspend.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->