### PR TITLE
Add power menu

### DIFF
--- a/applications/system-service/controller.h
+++ b/applications/system-service/controller.h
@@ -97,6 +97,24 @@ public:
   }
   Q_INVOKABLE void toggleSwipes() { systemAPI->toggleSwipes(); }
   Q_INVOKABLE void suspend() { systemAPI->suspend(); }
+  Q_INVOKABLE void powerOff() { systemAPI->powerOff(); }
+  Q_INVOKABLE void reboot() { systemAPI->reboot(); }
+  Q_INVOKABLE void pauseApplication(const QString& name, bool startIfNone) {
+    auto app = appsAPI->getApplication(name);
+    if (app != nullptr) {
+      app->pauseNoSecurityCheck(startIfNone);
+    }
+  }
+  Q_INVOKABLE void resumeApplication(const QString& name) {
+    auto app = appsAPI->getApplication(name);
+    if (app != nullptr) {
+      app->resumeNoSecurityCheck();
+    }
+  }
+  Q_INVOKABLE QString currentApplication() {
+    auto app = getCurrentApplication();
+    return app == nullptr ? "" : app->name();
+  }
 
   QString deviceName() { return deviceSettings.getDeviceName(); }
   bool leftSwipeEnabled() {
@@ -235,6 +253,11 @@ private:
       );
       m_switchMonitors.append({fd, notifier});
     }
+  }
+
+  Application* getCurrentApplication() {
+    auto path = appsAPI->currentApplicationNoSecurityCheck();
+    return path.path() == "/" ? nullptr : appsAPI->getApplication(path);
   }
 
   explicit Controller(QObject* parent = nullptr)

--- a/applications/system-service/controller.h
+++ b/applications/system-service/controller.h
@@ -115,6 +115,11 @@ public:
     auto app = getCurrentApplication();
     return app == nullptr ? "" : app->name();
   }
+  Q_INVOKABLE QString lockscreenApplication() {
+    auto path = appsAPI->lockscreenApplication();
+    auto app = path.path() == "/" ? nullptr : appsAPI->getApplication(path);
+    return app == nullptr ? "" : app->name();
+  }
 
   QString deviceName() { return deviceSettings.getDeviceName(); }
   bool leftSwipeEnabled() {

--- a/applications/system-service/main.qml
+++ b/applications/system-service/main.qml
@@ -1,5 +1,8 @@
 import QtQuick 2.15
 import QtQuick.Window 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.0
+import "qrc:/codes.eeems.oxide"
 
 Window{
     id: window
@@ -8,7 +11,7 @@ Window{
     width: Screen.width
     height: Screen.height
     visible: true
-    color: "transparent"
+    color: powerMenu.opened ? "white" : "transparent"
     property bool enableHeldKeys: controller.deviceName === "reMarkable 1"
 
     Connections{
@@ -63,9 +66,6 @@ Window{
                     break;
             }
         }
-    }
-    Connections{
-        target: controller
         function onLidClosed(){
             controller.suspend()
         }
@@ -96,9 +96,7 @@ Window{
         running: false
         repeat: false
         interval: 700
-        onTriggered:{
-            // TODO - power menu app
-        }
+        onTriggered: powerMenu.open()
     }
 
     Item{
@@ -196,5 +194,67 @@ Window{
         sequences: ["End+Alt+4", "Alt+F4", "Meta+Alt+4"]
         context: Qt.ApplicationShortcut
         onActivated: controller.close()
+    }
+    Popup {
+        id: powerMenu
+        modal: true
+        anchors.centerIn: parent
+        closePolicy: Popup.NoAutoClose
+        font.pixelSize: 48
+        implicitWidth: 500
+        implicitHeight: 500
+        Overlay.modal: Rectangle { color: "white" }
+        background: Rectangle { color: "white" }
+        property string resumeApplication: ""
+        onOpened: {
+            resumeApplication = controller.currentApplication();
+            controller.pauseApplication(resumeApplication, false);
+        }
+        onClosed: {
+            if(resumeApplication != ""){
+                controller.resumeApplication(resumeApplication);
+            }else{
+                controller.bac();
+            }
+        }
+        contentItem: ColumnLayout {
+            OxideButton {
+                text: "Suspend"
+                Layout.fillWidth: true
+                onClicked: {
+                    controller.suspend();
+                    powerMenu.close();
+                }
+            }
+            OxideButton {
+                text: "Reboot"
+                Layout.fillWidth: true
+                onClicked: {
+                    controller.reboot();
+                    powerMenu.close();
+                }
+            }
+            OxideButton {
+                text: "Shutdown"
+                Layout.fillWidth: true
+                onClicked: {
+                    controller.powerOff();
+                    powerMenu.close();
+                }
+            }
+            OxideButton {
+                text: "Lock"
+                Layout.fillWidth: true
+                onClicked: {
+                    controller.lock();
+                    powerMenu.close();
+                }
+            }
+            OxideButton {
+                text: "Cancel"
+                Layout.fillWidth: true
+                onClicked: powerMenu.close()
+            }
+        }
     }
 }

--- a/applications/system-service/main.qml
+++ b/applications/system-service/main.qml
@@ -214,7 +214,7 @@ Window{
             if(resumeApplication != ""){
                 controller.resumeApplication(resumeApplication);
             }else{
-                controller.bac();
+                controller.back();
             }
         }
         contentItem: ColumnLayout {
@@ -245,7 +245,10 @@ Window{
             OxideButton {
                 text: "Lock"
                 Layout.fillWidth: true
+                visible: powerMenu.resumeApplication != controller.lockscreenApplication()
+                enabled: visible
                 onClicked: {
+                    powerMenu.resumeApplication = "";
                     controller.lock();
                     powerMenu.close();
                 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an in-app power menu with actions to suspend, reboot, shut down, lock, and cancel.
  * When the power menu opens and closes, the currently active application is paused and then resumed (or falls back to the standard navigation behavior).
  * Enabled direct system power controls from the interface.
* **Bug Fixes**
  * Improved behavior when no current application is active.
  * Consolidated lid-close and power-button interaction handling for more consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->