### PR TITLE
QML cleanup

### DIFF
--- a/VELBUILD
+++ b/VELBUILD
@@ -148,11 +148,11 @@ postosupgrade() {
 
 predeinstall() {
     set -e
-    if [ "$(systemctl --quiet list-unit-files tarnish.service | /bin/grep -c tarnish.service 2> /dev/null)" -eq 1 ]; then
-        if systemctl --quiet is-active tarnish.service 2> /dev/null; then
+    if [ "$(systemctl --quiet list-unit-files tarnish.service | /bin/grep -c tarnish.service 2>/dev/null)" -eq 1 ]; then
+        if systemctl --quiet is-active tarnish.service 2>/dev/null; then
             systemctl stop tarnish.service
         fi
-        if systemctl --quiet is-enabled tarnish.service 2> /dev/null; then
+        if systemctl --quiet is-enabled tarnish.service 2>/dev/null; then
             systemctl disable tarnish.service
         fi
     fi
@@ -229,11 +229,11 @@ oxide_display() {
 
     predeinstall() {
         set -e
-        if [ "$(systemctl --quiet list-unit-files blight.service | /bin/grep -c blight.service 2> /dev/null)" -eq 1 ]; then
-            if systemctl --quiet is-active blight.service 2> /dev/null; then
+        if [ "$(systemctl --quiet list-unit-files blight.service | /bin/grep -c blight.service 2>/dev/null)" -eq 1 ]; then
+            if systemctl --quiet is-active blight.service 2>/dev/null; then
                 systemctl stop blight.service
             fi
-            if systemctl --quiet is-enabled blight.service 2> /dev/null; then
+            if systemctl --quiet is-enabled blight.service 2>/dev/null; then
                 systemctl disable blight.service
             fi
         fi
@@ -616,7 +616,9 @@ launcherctl() {
     }
     postinstall() {
         set -e
+        /home/root/.vellum/bin/mount-rw
         postosupgrade
+        /home/root/.vellum/bin/mount-restore
     }
     postupgrade() {
         set -e
@@ -644,7 +646,7 @@ launcherctl() {
     }
     postdeinstall() {
         set -e
-        if [ "$(systemctl --quiet list-unit-files xochitl.service | /bin/grep -c xochitl.service 2> /dev/null)" -ne 1 ]; then
+        if [ "$(systemctl --quiet list-unit-files xochitl.service | /bin/grep -c xochitl.service 2>/dev/null)" -ne 1 ]; then
             systemctl enable --now xochitl
         fi
     }

--- a/VELBUILD
+++ b/VELBUILD
@@ -148,11 +148,11 @@ postosupgrade() {
 
 predeinstall() {
     set -e
-    if [ "$(systemctl --quiet list-unit-files tarnish.service | /bin/grep -c tarnish.service 2>/dev/null)" -eq 1 ]; then
-        if systemctl --quiet is-active tarnish.service 2>/dev/null; then
+    if [ "$(systemctl --quiet list-unit-files tarnish.service | /bin/grep -c tarnish.service 2> /dev/null)" -eq 1 ]; then
+        if systemctl --quiet is-active tarnish.service 2> /dev/null; then
             systemctl stop tarnish.service
         fi
-        if systemctl --quiet is-enabled tarnish.service 2>/dev/null; then
+        if systemctl --quiet is-enabled tarnish.service 2> /dev/null; then
             systemctl disable tarnish.service
         fi
     fi
@@ -229,11 +229,11 @@ oxide_display() {
 
     predeinstall() {
         set -e
-        if [ "$(systemctl --quiet list-unit-files blight.service | /bin/grep -c blight.service 2>/dev/null)" -eq 1 ]; then
-            if systemctl --quiet is-active blight.service 2>/dev/null; then
+        if [ "$(systemctl --quiet list-unit-files blight.service | /bin/grep -c blight.service 2> /dev/null)" -eq 1 ]; then
+            if systemctl --quiet is-active blight.service 2> /dev/null; then
                 systemctl stop blight.service
             fi
-            if systemctl --quiet is-enabled blight.service 2>/dev/null; then
+            if systemctl --quiet is-enabled blight.service 2> /dev/null; then
                 systemctl disable blight.service
             fi
         fi
@@ -646,7 +646,7 @@ launcherctl() {
     }
     postdeinstall() {
         set -e
-        if [ "$(systemctl --quiet list-unit-files xochitl.service | /bin/grep -c xochitl.service 2>/dev/null)" -ne 1 ]; then
+        if [ "$(systemctl --quiet list-unit-files xochitl.service | /bin/grep -c xochitl.service 2> /dev/null)" -ne 1 ]; then
             systemctl enable --now xochitl
         fi
     }

--- a/VELBUILD
+++ b/VELBUILD
@@ -59,7 +59,7 @@ build() {
         exit 1
         ;;
     esac
-    make FEATURES=sentry release
+    make FEATURES=sentry,debug release
 }
 
 package() {

--- a/applications/display-server/Workspace.qml
+++ b/applications/display-server/Workspace.qml
@@ -11,11 +11,11 @@ ApplicationWindow {
     y: 0
     visible: true
     function loadComponent(url: string, props): string{
-        var comp = Qt.createComponent(url, Component.PreferSynchronous);
-        if(comp.status === Component.Error){
-            return comp.errorString();
+        var component = Qt.createComponent(url, Component.PreferSynchronous);
+        if(component.status === Component.Error){
+            return component.errorString();
         }
-        return comp.createObject(workspace, props).objectName;
+        return component.createObject(workspace, props).objectName;
     }
     background: Rectangle{
         color: "white"

--- a/applications/display-server/dbusinterface.cpp
+++ b/applications/display-server/dbusinterface.cpp
@@ -97,7 +97,7 @@ void
 DbusInterface::startup() {
 #ifndef EPAPER
   if (
-    Oxide::QML::loadQml(&engine, QUrl(QStringLiteral("qrc:/Workspace.qml"))) ==
+    Oxide::QML::loadQML(&engine, QUrl(QStringLiteral("qrc:/Workspace.qml"))) ==
     nullptr
   ) {
     qFatal("Failed to load main layout");

--- a/applications/display-server/dbusinterface.cpp
+++ b/applications/display-server/dbusinterface.cpp
@@ -5,6 +5,7 @@
 #include <liboxide/dbus_types.h>
 #include <liboxide/debug.h>
 #include <liboxide/devicesettings.h>
+#include <liboxide/oxideqml.h>
 #include <liboxide/threading.h>
 #include <memory>
 #include <sys/poll.h>
@@ -36,11 +37,6 @@ DbusInterface::DbusInterface(QObject* parent)
   }
 #ifdef EPAPER
   guiThread;
-#else
-  engine.load(QUrl(QStringLiteral("qrc:/Workspace.qml")));
-  if (engine.rootObjects().isEmpty()) {
-    qFatal("Failed to load main layout");
-  }
 #endif
   // Needed to trick QtDBus into exposing the object
   setProperty("__init__", true);
@@ -95,6 +91,18 @@ DbusInterface::singleton() {
     });
   });
   return instance;
+}
+
+void
+DbusInterface::startup() {
+#ifndef EPAPER
+  if (
+    Oxide::QML::loadQml(&engine, QUrl(QStringLiteral("qrc:/Workspace.qml"))) ==
+    nullptr
+  ) {
+    qFatal("Failed to load main layout");
+  }
+#endif
 }
 
 int

--- a/applications/display-server/dbusinterface.h
+++ b/applications/display-server/dbusinterface.h
@@ -50,6 +50,7 @@ class DbusInterface
 public:
   static DbusInterface* singleton();
 
+  void startup();
   int pid();
 #ifndef EPAPER
   QObject* loadComponent(

--- a/applications/display-server/main.cpp
+++ b/applications/display-server/main.cpp
@@ -143,6 +143,7 @@ main(int argc, char* argv[]) {
   });
   dbusInterface;
   evdevHandler;
+  QTimer::singleShot(0, [] { dbusInterface->startup(); });
   ::signal(SIGPIPE, SIG_IGN);
   ::signal(SIGBUS, SIG_IGN);
   return app.exec();

--- a/applications/launcher/main.cpp
+++ b/applications/launcher/main.cpp
@@ -53,7 +53,7 @@ main(int argc, char* argv[]) {
   );
   context->setContextProperty("controller", controller);
   QTimer::singleShot(0, [&app, &engine, controller] {
-    QObject* root = loadQml(&engine, QUrl(QStringLiteral("qrc:/main.qml")));
+    QObject* root = loadQML(&engine, QUrl(QStringLiteral("qrc:/main.qml")));
     if (root == nullptr) {
       qDebug() << "Nothing to display";
       qApp->exit(EXIT_FAILURE);

--- a/applications/launcher/main.cpp
+++ b/applications/launcher/main.cpp
@@ -52,48 +52,52 @@ main(int argc, char* argv[]) {
     "apps", QVariant::fromValue(controller->getApps())
   );
   context->setContextProperty("controller", controller);
-  engine.load(QUrl(QStringLiteral("qrc:/main.qml")));
-  if (engine.rootObjects().isEmpty()) {
-    qDebug() << "Nothing to display";
-    return -1;
-  }
-  QObject* root = engine.rootObjects().first();
-  controller->root = root;
-  root->installEventFilter(new EventFilter(&app));
-  QObject* stateController = root->findChild<QObject*>("stateController");
-  if (!stateController) {
-    qDebug() << "Can't find stateController";
-    return -1;
-  }
-  controller->stateController = stateController;
-  QObject* clock = root->findChild<QObject*>("clock");
-  if (!clock) {
-    qDebug() << "Can't find clock";
-    return -1;
-  }
-  // Update UI
-  clock->setProperty("text", QTime::currentTime().toString("h:mm a"));
-  controller->updateUIElements();
-  // Setup clock
-  QTimer* clockTimer = new QTimer(root);
-  auto currentTime = QTime::currentTime();
-  QTime nextTime = currentTime.addSecs(60 - currentTime.second());
-  clockTimer->setInterval(currentTime.msecsTo(nextTime)); // nearest minute
-  QObject::connect(
-    clockTimer, &QTimer::timeout, [clock, &clockTimer, controller]() {
-      QString text = "";
-      if (controller->showDate()) {
-        text = QDate::currentDate().toString(Qt::TextDate) + " ";
-      }
-      clock->setProperty(
-        "text", text + QTime::currentTime().toString("h:mm a")
-      );
-      if (clockTimer->interval() != 60 * 1000) {
-        clockTimer->setInterval(60 * 1000); // 1 minute
-      }
+  QTimer::singleShot(0, [&app, &engine, controller] {
+    QObject* root = loadQml(&engine, QUrl(QStringLiteral("qrc:/main.qml")));
+    if (root == nullptr) {
+      qDebug() << "Nothing to display";
+      qApp->exit(EXIT_FAILURE);
+      return;
     }
-  );
-  clockTimer->start();
+    controller->root = root;
+    root->installEventFilter(new EventFilter(&app));
+    QObject* stateController = root->findChild<QObject*>("stateController");
+    if (!stateController) {
+      qDebug() << "Can't find stateController";
+      qApp->exit(EXIT_FAILURE);
+      return;
+    }
+    controller->stateController = stateController;
+    QObject* clock = root->findChild<QObject*>("clock");
+    if (!clock) {
+      qDebug() << "Can't find clock";
+      qApp->exit(EXIT_FAILURE);
+      return;
+    }
+    // Update UI
+    clock->setProperty("text", QTime::currentTime().toString("h:mm a"));
+    controller->updateUIElements();
+    // Setup clock
+    QTimer* clockTimer = new QTimer(root);
+    auto currentTime = QTime::currentTime();
+    QTime nextTime = currentTime.addSecs(60 - currentTime.second());
+    clockTimer->setInterval(currentTime.msecsTo(nextTime)); // nearest minute
+    QObject::connect(
+      clockTimer, &QTimer::timeout, [clock, clockTimer, controller]() {
+        QString text = "";
+        if (controller->showDate()) {
+          text = QDate::currentDate().toString(Qt::TextDate) + " ";
+        }
+        clock->setProperty(
+          "text", text + QTime::currentTime().toString("h:mm a")
+        );
+        if (clockTimer->interval() != 60 * 1000) {
+          clockTimer->setInterval(60 * 1000); // 1 minute
+        }
+      }
+    );
+    clockTimer->start();
+  });
   shutdown_handler = [&controller](int signum) {
     Q_UNUSED(signum)
     QTimer::singleShot(300, [=]() { emit controller->reload(); });

--- a/applications/lockscreen/main.cpp
+++ b/applications/lockscreen/main.cpp
@@ -30,7 +30,7 @@ main(int argc, char* argv[]) {
   QQmlContext* context = engine.rootContext();
   context->setContextProperty("controller", &controller);
   QTimer::singleShot(0, [&app, &engine, &controller] {
-    QObject* root = loadQml(&engine, QUrl(QStringLiteral("qrc:/main.qml")));
+    QObject* root = loadQML(&engine, QUrl(QStringLiteral("qrc:/main.qml")));
     if (root == nullptr) {
       qDebug() << "Nothing to display";
       qApp->exit(EXIT_FAILURE);

--- a/applications/lockscreen/main.cpp
+++ b/applications/lockscreen/main.cpp
@@ -29,14 +29,16 @@ main(int argc, char* argv[]) {
   registerQML(&engine);
   QQmlContext* context = engine.rootContext();
   context->setContextProperty("controller", &controller);
-  engine.load(QUrl(QStringLiteral("qrc:/main.qml")));
-  if (engine.rootObjects().isEmpty()) {
-    qDebug() << "Nothing to display";
-    return -1;
-  }
-  auto root = engine.rootObjects().first();
-  root->installEventFilter(new EventFilter(&app));
-  controller.setRoot(root);
-  qDebug() << root;
+  QTimer::singleShot(0, [&app, &engine, &controller] {
+    QObject* root = loadQml(&engine, QUrl(QStringLiteral("qrc:/main.qml")));
+    if (root == nullptr) {
+      qDebug() << "Nothing to display";
+      qApp->exit(EXIT_FAILURE);
+      return;
+    }
+    root->installEventFilter(new EventFilter(&app));
+    controller.setRoot(root);
+    qDebug() << root;
+  });
   return app.exec();
 }

--- a/applications/process-manager/main.cpp
+++ b/applications/process-manager/main.cpp
@@ -1,3 +1,4 @@
+#include <cstdlib>
 #include <fcntl.h>
 #include <liboxide.h>
 #include <liboxide/eventfilter.h>
@@ -33,17 +34,20 @@ main(int argc, char* argv[]) {
   QQmlContext* context = engine.rootContext();
   Controller controller(&engine);
   context->setContextProperty("controller", &controller);
-  engine.load(QUrl(QStringLiteral("qrc:/main.qml")));
-  if (engine.rootObjects().isEmpty()) {
-    qDebug() << "Nothing to display";
-    return -1;
-  }
-  QObject* root = engine.rootObjects().first();
-  root->installEventFilter(new EventFilter(&app));
-  QQuickItem* tasksView = root->findChild<QQuickItem*>("tasksView");
-  if (!tasksView) {
-    qDebug() << "Can't find tasksView";
-    return -1;
-  }
+  QTimer::singleShot(0, [&app, &engine] {
+    QObject* root = loadQml(&engine, QUrl(QStringLiteral("qrc:/main.qml")));
+    if (root == nullptr) {
+      qDebug() << "Nothing to display";
+      qApp->exit(EXIT_FAILURE);
+      return;
+    }
+    root->installEventFilter(new EventFilter(&app));
+    QQuickItem* tasksView = root->findChild<QQuickItem*>("tasksView");
+    if (!tasksView) {
+      qDebug() << "Can't find tasksView";
+      qApp->exit(EXIT_FAILURE);
+      return;
+    }
+  });
   return app.exec();
 }

--- a/applications/process-manager/main.cpp
+++ b/applications/process-manager/main.cpp
@@ -35,7 +35,7 @@ main(int argc, char* argv[]) {
   Controller controller(&engine);
   context->setContextProperty("controller", &controller);
   QTimer::singleShot(0, [&app, &engine] {
-    QObject* root = loadQml(&engine, QUrl(QStringLiteral("qrc:/main.qml")));
+    QObject* root = loadQML(&engine, QUrl(QStringLiteral("qrc:/main.qml")));
     if (root == nullptr) {
       qDebug() << "Nothing to display";
       qApp->exit(EXIT_FAILURE);

--- a/applications/screenshot-viewer/main.cpp
+++ b/applications/screenshot-viewer/main.cpp
@@ -42,7 +42,7 @@ main(int argc, char* argv[]) {
   signal(SIGTERM, sigHandler);
 
   QTimer::singleShot(0, [&app, &engine, &controller] {
-    QObject* root = loadQml(&engine, QUrl(QStringLiteral("qrc:/main.qml")));
+    QObject* root = loadQML(&engine, QUrl(QStringLiteral("qrc:/main.qml")));
     if (root == nullptr) {
       qDebug() << "Nothing to display";
       qApp->exit(EXIT_FAILURE);

--- a/applications/screenshot-viewer/main.cpp
+++ b/applications/screenshot-viewer/main.cpp
@@ -36,18 +36,20 @@ main(int argc, char* argv[]) {
   registerQML(&engine);
   QQmlContext* context = engine.rootContext();
   context->setContextProperty("controller", &controller);
-  engine.load(QUrl(QStringLiteral("qrc:/main.qml")));
-  if (engine.rootObjects().isEmpty()) {
-    qDebug() << "Nothing to display";
-    return -1;
-  }
-  auto root = engine.rootObjects().first();
-  root->installEventFilter(new EventFilter(&app));
-  controller.setRoot(root);
 
   signal(SIGINT, sigHandler);
   signal(SIGSEGV, sigHandler);
   signal(SIGTERM, sigHandler);
 
+  QTimer::singleShot(0, [&app, &engine, &controller] {
+    QObject* root = loadQml(&engine, QUrl(QStringLiteral("qrc:/main.qml")));
+    if (root == nullptr) {
+      qDebug() << "Nothing to display";
+      qApp->exit(EXIT_FAILURE);
+      return;
+    }
+    root->installEventFilter(new EventFilter(&app));
+    controller.setRoot(root);
+  });
   return app.exec();
 }

--- a/applications/sketchpad/main.cpp
+++ b/applications/sketchpad/main.cpp
@@ -25,7 +25,7 @@ main(int argc, char* argv[]) {
   QQmlApplicationEngine engine;
   registerQML(&engine);
   QTimer::singleShot(0, [&app, &engine] {
-    QObject* root = loadQml(&engine, QUrl(QStringLiteral("qrc:/main.qml")));
+    QObject* root = loadQML(&engine, QUrl(QStringLiteral("qrc:/main.qml")));
     if (root == nullptr) {
       qDebug() << "Nothing to display";
       qApp->exit(EXIT_FAILURE);

--- a/applications/sketchpad/main.cpp
+++ b/applications/sketchpad/main.cpp
@@ -24,14 +24,16 @@ main(int argc, char* argv[]) {
   app.setApplicationVersion(APP_VERSION);
   QQmlApplicationEngine engine;
   registerQML(&engine);
-  engine.load(QUrl(QStringLiteral("qrc:/main.qml")));
-  if (engine.rootObjects().isEmpty()) {
-    qDebug() << "Nothing to display";
-    return -1;
-  }
-  auto root = engine.rootObjects().first();
-  root->installEventFilter(new EventFilter(&app));
-  qDebug() << root;
+  QTimer::singleShot(0, [&app, &engine] {
+    QObject* root = loadQml(&engine, QUrl(QStringLiteral("qrc:/main.qml")));
+    if (root == nullptr) {
+      qDebug() << "Nothing to display";
+      qApp->exit(EXIT_FAILURE);
+      return;
+    }
+    root->installEventFilter(new EventFilter(&app));
+    qDebug() << root;
+  });
   app.setAttribute(Qt::AA_SynthesizeMouseForUnhandledTouchEvents, false);
   return app.exec();
 }

--- a/applications/system-service/appsapi.cpp
+++ b/applications/system-service/appsapi.cpp
@@ -1022,7 +1022,9 @@ AppsAPI::shutdown() {
       if (app->stateNoSecurityCheck() != Application::Inactive) {
         auto text = "Stopping " + app->displayName() + "...";
         O_DEBUG(text.toStdString().c_str());
-        notification->setProperty("text", text);
+        if (notification != nullptr) {
+          notification->setProperty("text", text);
+        }
       }
       app->stopNoSecurityCheck();
     }
@@ -1032,7 +1034,9 @@ AppsAPI::shutdown() {
       app->deleteLater();
     }
     applications.clear();
-    notification->setProperty("notificationVisible", false);
+    if (notification != nullptr) {
+      notification->setProperty("notificationVisible", false);
+    }
     if (buffer != nullptr) {
       auto image = Oxide::QML::getImageForSurface(buffer);
       QPainter painter(&image);

--- a/applications/system-service/controller.h
+++ b/applications/system-service/controller.h
@@ -132,6 +132,9 @@ public:
       return object;
     }
     auto buffer = Oxide::QML::getSurfaceForWindow(window);
+    if (buffer == nullptr) {
+      return object;
+    }
     getCompositorDBus()->setFlags(
       QString("connection/%1/surface/%2").arg(getpid()).arg(buffer->surface),
       QStringList() << "system"

--- a/applications/system-service/controller.h
+++ b/applications/system-service/controller.h
@@ -2,6 +2,7 @@
 
 #include <liboxide/debug.h>
 #include <liboxide/devicesettings.h>
+#include <liboxide/oxideqml.h>
 
 #include <QKeyEvent>
 #include <QList>
@@ -16,6 +17,7 @@
 
 #include "application.h"
 #include "appsapi.h"
+#include "dbusservice.h"
 #include "eventlistener.h"
 #include "screenapi.h"
 #include "systemapi.h"
@@ -119,6 +121,22 @@ public:
     auto path = appsAPI->lockscreenApplication();
     auto app = path.path() == "/" ? nullptr : appsAPI->getApplication(path);
     return app == nullptr ? "" : app->name();
+  }
+  Q_INVOKABLE QObject* loadQML(QUrl url) {
+    auto* object = Oxide::QML::loadQML(dbusService->engine(), url);
+    if (object == nullptr) {
+      return nullptr;
+    }
+    QWindow* window = qobject_cast<QQuickWindow*>(object);
+    if (window == nullptr) {
+      return object;
+    }
+    auto buffer = Oxide::QML::getSurfaceForWindow(window);
+    getCompositorDBus()->setFlags(
+      QString("connection/%1/surface/%2").arg(getpid()).arg(buffer->surface),
+      QStringList() << "system"
+    );
+    return object;
   }
 
   QString deviceName() { return deviceSettings.getDeviceName(); }

--- a/applications/system-service/main.cpp
+++ b/applications/system-service/main.cpp
@@ -225,19 +225,18 @@ main(int argc, char* argv[]) {
 
   QQmlApplicationEngine engine;
   registerQML(&engine);
-  QQmlContext* context = engine.rootContext();
-  context->setContextProperty("controller", Controller::singleton());
-  QUrl overlayUrl(sharedSettings.systemOverlay());
-  engine.load(overlayUrl);
-  if (engine.rootObjects().isEmpty()) {
-    O_WARNING("Failed to load system overlay:" << overlayUrl);
-    engine.load(QUrl(QStringLiteral("qrc:/main.qml")));
-    if (engine.rootObjects().isEmpty()) {
-      qWarning("Failed to load main layout");
-      return EXIT_FAILURE;
-    }
-  }
   QTimer::singleShot(0, [&engine, &buffer] {
+    QQmlContext* context = engine.rootContext();
+    context->setContextProperty("controller", Controller::singleton());
+    QUrl overlayUrl(sharedSettings.systemOverlay());
+    if (loadQml(&engine, overlayUrl) == nullptr) {
+      O_WARNING("Failed to load system overlay:" << overlayUrl);
+      if (loadQml(&engine, QUrl(QStringLiteral("qrc:/main.qml"))) == nullptr) {
+        qWarning("Failed to load main layout");
+        qApp->exit(EXIT_FAILURE);
+        return;
+      }
+    }
     dbusService->startup(&engine);
     Blight::connection()->remove(buffer);
   });

--- a/applications/system-service/main.cpp
+++ b/applications/system-service/main.cpp
@@ -159,16 +159,16 @@ main(int argc, char* argv[]) {
   });
   QTimer::singleShot(0, &app, [] {
     QObject::connect(signalHandler, &SignalHandler::sigTerm, qApp, [] {
-      dbusService->exit(SIGTERM);
+      dbusService->exit(0);
     });
     QObject::connect(signalHandler, &SignalHandler::sigInt, qApp, [] {
-      dbusService->exit(SIGINT);
+      dbusService->exit(0);
     });
     QObject::connect(signalHandler, &SignalHandler::sigSegv, qApp, [] {
-      dbusService->exit(SIGSEGV);
+      dbusService->exit(128 + SIGSEGV);
     });
     QObject::connect(signalHandler, &SignalHandler::sigBus, qApp, [] {
-      dbusService->exit(SIGBUS);
+      dbusService->exit(128 + SIGBUS);
     });
   });
 
@@ -228,10 +228,19 @@ main(int argc, char* argv[]) {
   QTimer::singleShot(0, [&engine, &buffer] {
     QQmlContext* context = engine.rootContext();
     context->setContextProperty("controller", Controller::singleton());
-    QUrl overlayUrl(sharedSettings.systemOverlay());
-    if (loadQml(&engine, overlayUrl) == nullptr) {
-      O_WARNING("Failed to load system overlay:" << overlayUrl);
-      if (loadQml(&engine, QUrl(QStringLiteral("qrc:/main.qml"))) == nullptr) {
+    auto url = QUrl::fromUserInput(
+      sharedSettings.systemOverlay(), QDir::currentPath(), QUrl::AssumeLocalFile
+    );
+    if (url.scheme().isEmpty()) {
+      url.setScheme("file");
+    }
+    QWindow* root = qobject_cast<QWindow*>(loadQML(&engine, url));
+    if (root == nullptr) {
+      O_WARNING("Failed to load system overlay:" << url);
+      root = qobject_cast<QWindow*>(
+        loadQML(&engine, QUrl(QStringLiteral("qrc:/main.qml")))
+      );
+      if (root == nullptr) {
         qWarning("Failed to load main layout");
         qApp->exit(EXIT_FAILURE);
         return;

--- a/applications/system-service/notification.cpp
+++ b/applications/system-service/notification.cpp
@@ -225,9 +225,11 @@ void
 Notification::paintNotification() {
   O_INFO("Painting notification" << identifier());
   auto window = notificationAPI->paintNotification(m_text, m_icon, m_actions);
-  QObject::connect(
-    window, SIGNAL(clicked(QString)), this, SIGNAL(clicked(QString))
-  );
+  if (window != nullptr) {
+    QObject::connect(
+      window, SIGNAL(clicked(QString)), this, SIGNAL(clicked(QString))
+    );
+  }
   auto connection = std::make_shared<QMetaObject::Connection>(QObject::connect(
     this,
     &Notification::removed,
@@ -250,11 +252,13 @@ Notification::paintNotification() {
 void
 Notification::nextNotification(QQuickWindow* window) {
   O_INFO("Finished displaying notification" << identifier());
-  disconnect(window, SIGNAL(clicked(QString)), nullptr, nullptr);
+  if (window != nullptr) {
+    disconnect(window, SIGNAL(clicked(QString)), nullptr, nullptr);
+  }
   if (!notificationAPI->notificationDisplayQueue.isEmpty()) {
     notificationAPI->notificationDisplayQueue.takeFirst()->paintNotification();
     return;
-  } else {
+  } else if (window != nullptr) {
     window->setProperty("notificationVisible", false);
   }
   notificationAPI->unlock();

--- a/applications/system-service/notificationapi.cpp
+++ b/applications/system-service/notificationapi.cpp
@@ -81,7 +81,6 @@ NotificationAPI::startup() {
       qFatal("Failed to load notification overlay");
     }
   }
-  m_window = qobject_cast<QQuickWindow*>(rootObject);
   auto buffer = Oxide::QML::getSurfaceForWindow(m_window);
   getCompositorDBus()->setFlags(
     QString("connection/%1/surface/%2").arg(getpid()).arg(buffer->surface),

--- a/applications/system-service/notificationapi.cpp
+++ b/applications/system-service/notificationapi.cpp
@@ -35,9 +35,11 @@ NotificationAPI::NotificationAPI(QObject* parent)
 
 void
 NotificationAPI::shutdown() {
-  m_window->close();
-  delete m_window;
-  m_window = nullptr;
+  if (m_window != nullptr) {
+    m_window->close();
+    delete m_window;
+    m_window = nullptr;
+  }
 }
 
 bool
@@ -62,15 +64,17 @@ void
 NotificationAPI::startup() {
   auto engine = dbusService->engine();
   QUrl overlayUrl(sharedSettings.notificationOverlay());
-  engine->load(overlayUrl);
-  if (engine->rootObjects().count() < 2) {
+  QObject* obj = Oxide::QML::loadQml(engine, overlayUrl);
+  if (obj == nullptr) {
     O_WARNING("Failed to load notification overlay:" << overlayUrl);
-    engine->load(QUrl(QStringLiteral("qrc:/notification.qml")));
-    if (engine->rootObjects().count() < 2) {
+    obj = Oxide::QML::loadQml(
+      engine, QUrl(QStringLiteral("qrc:/notification.qml"))
+    );
+    if (obj == nullptr) {
       qFatal("Failed to load notification overlay");
     }
   }
-  m_window = static_cast<QQuickWindow*>(engine->rootObjects().last());
+  m_window = qobject_cast<QQuickWindow*>(obj);
   auto buffer = Oxide::QML::getSurfaceForWindow(m_window);
   getCompositorDBus()->setFlags(
     QString("connection/%1/surface/%2").arg(getpid()).arg(buffer->surface),
@@ -160,6 +164,9 @@ NotificationAPI::paintNotification(
   const QString& iconPath,
   const QVariantMap& actions
 ) {
+  if (m_window == nullptr) {
+    return nullptr;
+  }
   m_window->setProperty("text", text);
   if (!iconPath.isEmpty() && QFileInfo(iconPath).exists()) {
     m_window->setProperty("image", QUrl::fromLocalFile(iconPath));

--- a/applications/system-service/notificationapi.cpp
+++ b/applications/system-service/notificationapi.cpp
@@ -63,18 +63,25 @@ NotificationAPI::setEnabled(bool enabled) {
 void
 NotificationAPI::startup() {
   auto engine = dbusService->engine();
-  QUrl overlayUrl(sharedSettings.notificationOverlay());
-  QObject* obj = Oxide::QML::loadQml(engine, overlayUrl);
-  if (obj == nullptr) {
-    O_WARNING("Failed to load notification overlay:" << overlayUrl);
-    obj = Oxide::QML::loadQml(
-      engine, QUrl(QStringLiteral("qrc:/notification.qml"))
+  auto url = QUrl::fromUserInput(
+    sharedSettings.notificationOverlay(),
+    QDir::currentPath(),
+    QUrl::AssumeLocalFile
+  );
+  if (url.scheme().isEmpty()) {
+    url.setScheme("file");
+  }
+  m_window = qobject_cast<QQuickWindow*>(Oxide::QML::loadQML(engine, url));
+  if (m_window == nullptr) {
+    O_WARNING("Failed to load notification overlay:" << url);
+    m_window = qobject_cast<QQuickWindow*>(
+      Oxide::QML::loadQML(engine, QUrl(QStringLiteral("qrc:/notification.qml")))
     );
-    if (obj == nullptr) {
+    if (m_window == nullptr) {
       qFatal("Failed to load notification overlay");
     }
   }
-  m_window = qobject_cast<QQuickWindow*>(obj);
+  m_window = qobject_cast<QQuickWindow*>(rootObject);
   auto buffer = Oxide::QML::getSurfaceForWindow(m_window);
   getCompositorDBus()->setFlags(
     QString("connection/%1/surface/%2").arg(getpid()).arg(buffer->surface),

--- a/applications/task-switcher/main.cpp
+++ b/applications/task-switcher/main.cpp
@@ -37,17 +37,19 @@ main(int argc, char* argv[]) {
     "apps", QVariant::fromValue(controller.getApps())
   );
   context->setContextProperty("controller", &controller);
-  engine.load(QUrl(QStringLiteral("qrc:/main.qml")));
-  if (engine.rootObjects().isEmpty()) {
-    qDebug() << "Nothing to display";
-    return -1;
-  }
-  auto root = engine.rootObjects().first();
-  controller.setRoot(root);
 
   signal(SIGINT, sigHandler);
   signal(SIGSEGV, sigHandler);
   signal(SIGTERM, sigHandler);
 
+  QTimer::singleShot(0, [&engine, &controller] {
+    QObject* root = loadQml(&engine, QUrl(QStringLiteral("qrc:/main.qml")));
+    if (root == nullptr) {
+      qDebug() << "Nothing to display";
+      qApp->exit(EXIT_FAILURE);
+      return;
+    }
+    controller.setRoot(root);
+  });
   return app.exec();
 }

--- a/applications/task-switcher/main.cpp
+++ b/applications/task-switcher/main.cpp
@@ -43,7 +43,7 @@ main(int argc, char* argv[]) {
   signal(SIGTERM, sigHandler);
 
   QTimer::singleShot(0, [&engine, &controller] {
-    QObject* root = loadQml(&engine, QUrl(QStringLiteral("qrc:/main.qml")));
+    QObject* root = loadQML(&engine, QUrl(QStringLiteral("qrc:/main.qml")));
     if (root == nullptr) {
       qDebug() << "Nothing to display";
       qApp->exit(EXIT_FAILURE);

--- a/shared/liboxide/oxideqml.cpp
+++ b/shared/liboxide/oxideqml.cpp
@@ -345,6 +345,7 @@ namespace Oxide {
       }
       if (loop.exec(QEventLoop::ExcludeUserInputEvents)) {
         O_WARNING("Timed out waiting for qml to load:" << url);
+        QObject::disconnect(connection);
         return nullptr;
       }
       QObject::disconnect(connection);

--- a/shared/liboxide/oxideqml.cpp
+++ b/shared/liboxide/oxideqml.cpp
@@ -3,12 +3,15 @@
 #include <libblight.h>
 #include <libblight/connection.h>
 
+#include <QCoreApplication>
+#include <QEventLoop>
 #include <QFunctionPointer>
 #include <QGuiApplication>
 #include <QPainter>
 #include <QQuickWindow>
 #include <atomic>
 
+#include "debug.h"
 #include "liboxide.h"
 
 static std::atomic<unsigned int> marker = 0;
@@ -87,6 +90,49 @@ namespace Oxide {
       context->setContextProperty("Oxide", getSingleton());
       engine->addImportPath("qrc:/codes.eeems.oxide");
       qmlRegisterType<OxideCanvas>("codes.eeems.oxide", 3, 0, "OxideCanvas");
+    }
+
+    QObject* loadQml(QQmlApplicationEngine* engine, const QUrl& url) {
+      QObject* rootObject = nullptr;
+      QEventLoop loop;
+      QTimer timer;
+      timer.setSingleShot(true);
+      timer.setInterval(30 * 1000);
+      timer.callOnTimeout([&loop]() { loop.exit(1); });
+      QTimer::singleShot(0, [&engine, &url, &timer]() {
+        engine->load(url);
+        timer.start();
+      });
+      QMetaObject::Connection connection;
+      connection = QObject::connect(
+        engine,
+        &QQmlApplicationEngine::objectCreated,
+        [&rootObject, &loop, &url, &timer](
+          QObject* object, const QUrl& objectUrl
+        ) {
+          O_INFO(
+            "Object created: " << object << objectUrl << " expected:" << url
+          );
+          auto flags = QUrl::PreferLocalFile | QUrl::StripTrailingSlash |
+                       QUrl::NormalizePathSegments;
+          if (url.url(flags) != objectUrl.url(flags)) {
+            return;
+          }
+          rootObject = object;
+          timer.stop();
+          loop.quit();
+        }
+      );
+      if (!connection) {
+        O_WARNING("Failed to connect to QQmlApplicationEngine::objectCreated");
+        return nullptr;
+      }
+      if (loop.exec(QEventLoop::ExcludeUserInputEvents)) {
+        O_WARNING("Timed out waiting for qml to load:" << url);
+        return nullptr;
+      }
+      QObject::disconnect(connection);
+      return rootObject;
     }
 
     OxideCanvas::OxideCanvas(QQuickItem* parent)

--- a/shared/liboxide/oxideqml.cpp
+++ b/shared/liboxide/oxideqml.cpp
@@ -4,7 +4,10 @@
 #include <libblight/connection.h>
 
 #include <QCoreApplication>
+#include <QDir>
 #include <QEventLoop>
+#include <QFileInfo>
+#include <QFileSystemWatcher>
 #include <QFunctionPointer>
 #include <QGuiApplication>
 #include <QPainter>
@@ -78,61 +81,6 @@ namespace Oxide {
       Qt::PenJoinStyle join
     ) {
       return QPen(brush, width, style, cap, join);
-    }
-
-    OxideQml* getSingleton() {
-      static OxideQml* instance = new OxideQml(qApp);
-      return instance;
-    }
-
-    void registerQML(QQmlApplicationEngine* engine) {
-      QQmlContext* context = engine->rootContext();
-      context->setContextProperty("Oxide", getSingleton());
-      engine->addImportPath("qrc:/codes.eeems.oxide");
-      qmlRegisterType<OxideCanvas>("codes.eeems.oxide", 3, 0, "OxideCanvas");
-    }
-
-    QObject* loadQml(QQmlApplicationEngine* engine, const QUrl& url) {
-      QObject* rootObject = nullptr;
-      QEventLoop loop;
-      QTimer timer;
-      timer.setSingleShot(true);
-      timer.setInterval(30 * 1000);
-      timer.callOnTimeout([&loop]() { loop.exit(1); });
-      QTimer::singleShot(0, [&engine, &url, &timer]() {
-        engine->load(url);
-        timer.start();
-      });
-      QMetaObject::Connection connection;
-      connection = QObject::connect(
-        engine,
-        &QQmlApplicationEngine::objectCreated,
-        [&rootObject, &loop, &url, &timer](
-          QObject* object, const QUrl& objectUrl
-        ) {
-          O_INFO(
-            "Object created: " << object << objectUrl << " expected:" << url
-          );
-          auto flags = QUrl::PreferLocalFile | QUrl::StripTrailingSlash |
-                       QUrl::NormalizePathSegments;
-          if (url.url(flags) != objectUrl.url(flags)) {
-            return;
-          }
-          rootObject = object;
-          timer.stop();
-          loop.quit();
-        }
-      );
-      if (!connection) {
-        O_WARNING("Failed to connect to QQmlApplicationEngine::objectCreated");
-        return nullptr;
-      }
-      if (loop.exec(QEventLoop::ExcludeUserInputEvents)) {
-        O_WARNING("Timed out waiting for qml to load:" << url);
-        return nullptr;
-      }
-      QObject::disconnect(connection);
-      return rootObject;
     }
 
     OxideCanvas::OxideCanvas(QQuickItem* parent)
@@ -343,6 +291,64 @@ namespace Oxide {
         buffer->stride,
         (QImage::Format)buffer->format
       );
+    }
+
+    OxideQml* getSingleton() {
+      static OxideQml* instance = new OxideQml(qApp);
+      return instance;
+    }
+
+    void registerQML(QQmlApplicationEngine* engine) {
+      QQmlContext* context = engine->rootContext();
+      context->setContextProperty("Oxide", getSingleton());
+      engine->addImportPath("qrc:/codes.eeems.oxide");
+      qmlRegisterType<OxideCanvas>("codes.eeems.oxide", 3, 0, "OxideCanvas");
+    }
+
+    QObject* loadQML(QQmlApplicationEngine* engine, const QUrl& url) {
+      QObject* rootObject = nullptr;
+      QEventLoop loop;
+      QTimer timer;
+      timer.setSingleShot(true);
+      timer.setInterval(30 * 1000);
+      timer.callOnTimeout([&loop]() { loop.exit(1); });
+      QTimer::singleShot(0, [&engine, &url, &timer]() {
+        engine->load(url);
+        timer.start();
+      });
+      QMetaObject::Connection connection;
+      connection = QObject::connect(
+        engine,
+        &QQmlApplicationEngine::objectCreated,
+        [&rootObject, &loop, &url, &timer](
+          QObject* object, const QUrl& objectUrl
+        ) {
+          auto flags = QUrl::PreferLocalFile | QUrl::StripTrailingSlash |
+                       QUrl::NormalizePathSegments;
+          auto expectedUrl = url.url(flags);
+          auto actualUrl = objectUrl.url(flags);
+          O_DEBUG(
+            "Object created: " << object << actualUrl
+                               << ", expected:" << expectedUrl
+          );
+          if (expectedUrl != actualUrl) {
+            return;
+          }
+          rootObject = object;
+          timer.stop();
+          loop.quit();
+        }
+      );
+      if (!connection) {
+        O_WARNING("Failed to connect to QQmlApplicationEngine::objectCreated");
+        return nullptr;
+      }
+      if (loop.exec(QEventLoop::ExcludeUserInputEvents)) {
+        O_WARNING("Timed out waiting for qml to load:" << url);
+        return nullptr;
+      }
+      QObject::disconnect(connection);
+      return rootObject;
     }
   } // namespace QML
 } // namespace Oxide

--- a/shared/liboxide/oxideqml.h
+++ b/shared/liboxide/oxideqml.h
@@ -335,6 +335,18 @@ namespace Oxide {
      * with `import codes.eeems.oxide 3.0`
      */
     LIBOXIDE_EXPORT void registerQML(QQmlApplicationEngine* engine);
+    /*!
+     * \brief Load a QML file and return the created root object.
+     * \param engine The QQmlApplicationEngine to load into
+     * \param url The URL of the QML file to load
+     * \return The created QObject, or nullptr on failure
+     * \sa registerQML
+     *
+     * Loads QML synchronously. For asynchronous URLs (user-provided),
+     * use QQmlApplicationEngine::objectCreated directly.
+     */
+    LIBOXIDE_EXPORT QObject*
+    loadQml(QQmlApplicationEngine* engine, const QUrl& url);
   } // namespace QML
 } // namespace Oxide
 /*! @} */

--- a/shared/liboxide/oxideqml.h
+++ b/shared/liboxide/oxideqml.h
@@ -8,11 +8,13 @@
 
 #include "liboxide_global.h"
 
+#include <functional>
 #include <libblight/clock.h>
 #include <libblight/types.h>
 #include <mutex>
 
 #include <QBrush>
+#include <QFileSystemWatcher>
 #include <QImage>
 #include <QObject>
 #include <QPen>
@@ -340,13 +342,10 @@ namespace Oxide {
      * \param engine The QQmlApplicationEngine to load into
      * \param url The URL of the QML file to load
      * \return The created QObject, or nullptr on failure
-     * \sa registerQML
-     *
-     * Loads QML synchronously. For asynchronous URLs (user-provided),
-     * use QQmlApplicationEngine::objectCreated directly.
+     * \sa enableHotReload
      */
     LIBOXIDE_EXPORT QObject*
-    loadQml(QQmlApplicationEngine* engine, const QUrl& url);
+    loadQML(QQmlApplicationEngine* engine, const QUrl& url);
   } // namespace QML
 } // namespace Oxide
 /*! @} */

--- a/tests/test_app/main.cpp
+++ b/tests/test_app/main.cpp
@@ -256,16 +256,17 @@ main(int argc, char* argv[]) {
   QTimer::singleShot(0, [&engine] {
     if (loadQML(&engine, QUrl(QStringLiteral("qrc:/main.qml"))) == nullptr) {
       O_WARNING("Nothing to display");
-      qApp->quit();
+      qApp->exit(EXIT_FAILURE);
       return;
     }
-    QObject* notificationObj =
-      loadQML(&engine, QUrl(QStringLiteral("qrc:/notification.qml")));
-    if (notificationObj == nullptr) {
-      qApp->quit();
+    auto* notification = qobject_cast<QQuickWindow*>(
+      loadQML(&engine, QUrl(QStringLiteral("qrc:/notification.qml")))
+    );
+    if (notification == nullptr) {
+      O_WARNING("Could not load notification.qml");
+      qApp->exit(EXIT_FAILURE);
       return;
     }
-    auto notification = qobject_cast<QQuickWindow*>(notificationObj);
     notification->setProperty("text", "Testing");
     notification->setProperty(
       "image", QUrl::fromLocalFile(SPLASH_INSTALL_PATH "/oxide.png")

--- a/tests/test_app/main.cpp
+++ b/tests/test_app/main.cpp
@@ -254,13 +254,13 @@ main(int argc, char* argv[]) {
   QQmlApplicationEngine engine;
   registerQML(&engine);
   QTimer::singleShot(0, [&engine] {
-    if (loadQml(&engine, QUrl(QStringLiteral("qrc:/main.qml"))) == nullptr) {
+    if (loadQML(&engine, QUrl(QStringLiteral("qrc:/main.qml"))) == nullptr) {
       O_WARNING("Nothing to display");
       qApp->quit();
       return;
     }
     QObject* notificationObj =
-      loadQml(&engine, QUrl(QStringLiteral("qrc:/notification.qml")));
+      loadQML(&engine, QUrl(QStringLiteral("qrc:/notification.qml")));
     if (notificationObj == nullptr) {
       qApp->quit();
       return;

--- a/tests/test_app/main.cpp
+++ b/tests/test_app/main.cpp
@@ -253,19 +253,26 @@ main(int argc, char* argv[]) {
   }
   QQmlApplicationEngine engine;
   registerQML(&engine);
-  engine.load(QUrl(QStringLiteral("qrc:/main.qml")));
-  if (engine.rootObjects().isEmpty()) {
-    O_WARNING("Nothing to display");
-    return EXIT_FAILURE;
-  }
-  engine.load(QUrl(QStringLiteral("qrc:/notification.qml")));
-  auto notification = static_cast<QQuickWindow*>(engine.rootObjects().last());
-  notification->setProperty("text", "Testing");
-  notification->setProperty(
-    "image", QUrl::fromLocalFile(SPLASH_INSTALL_PATH "/oxide.png")
-  );
-  notification->setProperty("notificationVisible", true);
-  notification->raise();
+  QTimer::singleShot(0, [&engine] {
+    if (loadQml(&engine, QUrl(QStringLiteral("qrc:/main.qml"))) == nullptr) {
+      O_WARNING("Nothing to display");
+      qApp->quit();
+      return;
+    }
+    QObject* notificationObj =
+      loadQml(&engine, QUrl(QStringLiteral("qrc:/notification.qml")));
+    if (notificationObj == nullptr) {
+      qApp->quit();
+      return;
+    }
+    auto notification = qobject_cast<QQuickWindow*>(notificationObj);
+    notification->setProperty("text", "Testing");
+    notification->setProperty(
+      "image", QUrl::fromLocalFile(SPLASH_INSTALL_PATH "/oxide.png")
+    );
+    notification->setProperty("notificationVisible", true);
+    notification->raise();
+  });
   app.setAttribute(Qt::AA_SynthesizeMouseForUnhandledTouchEvents, false);
   int res = app.exec();
   O_INFO("Exit:" << res);


### PR DESCRIPTION
- Cleanup qml loading code
- Fix crash on exit of system service
- Fix launcherctl-failure.service install

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared QML loading helper used across apps and system services.
  * Display-server DBus interface now runs an explicit QML startup step.
  * System-service Controller gained a QML-loading entry point for overlays/surfaces.
* **Bug Fixes**
  * Launcher, lockscreen, process manager, screenshot viewer, sketchpad, task switcher, and test app now defer QML initialization for more reliable startup.
  * Improved handling when QML roots/windows fail to load, with more consistent failure termination.
  * Added null-safety for notification and window handling.
* **Build / Packaging**
  * Release builds now include additional debug feature flags; launcherctl upgrade remounts filesystem read-write during update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->