### PR TITLE
Allow reloading system service UI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,10 @@ BUILDNAME?=oxide
 TOOLCHAIN?=5.7.119
 
 ifneq ($(filter debug,$(FEATURES)),)
-DEFINES += CONFIG+="debug"
+CONFIG += CONFIG+="debug"
 endif
 ifneq ($(filter sentry,$(FEATURES)),)
-DEFINES += DEFINES+=SENTRY
+CONFIG += DEFINES+=SENTRY
 endif
 
 OBJ = oxide.pro
@@ -207,7 +207,7 @@ $(BUILD)/$(BUILDNAME): $(BUILD)/.nobackup
 	mkdir -p $(BUILD)/$(BUILDNAME)
 
 $(BUILD)/$(BUILDNAME)/Makefile: $(BUILD)/$(BUILDNAME)
-	cd $(BUILD)/$(BUILDNAME) && qmake -r $(DEFINES) $(CURDIR)
+	cd $(BUILD)/$(BUILDNAME) && qmake -r $(CONFIG) $(CURDIR)
 
 $(BUILD)/package:
 	mkdir -p $(BUILD)/package

--- a/VELBUILD
+++ b/VELBUILD
@@ -59,7 +59,7 @@ build() {
         exit 1
         ;;
     esac
-    make FEATURES=sentry,debug release
+    make FEATURES='sentry debug' release
 }
 
 package() {
@@ -148,11 +148,11 @@ postosupgrade() {
 
 predeinstall() {
     set -e
-    if [ "$(systemctl --quiet list-unit-files tarnish.service | /bin/grep -c tarnish.service 2> /dev/null)" -eq 1 ]; then
-        if systemctl --quiet is-active tarnish.service 2> /dev/null; then
+    if [ "$(systemctl --quiet list-unit-files tarnish.service | /bin/grep -c tarnish.service 2>/dev/null)" -eq 1 ]; then
+        if systemctl --quiet is-active tarnish.service 2>/dev/null; then
             systemctl stop tarnish.service
         fi
-        if systemctl --quiet is-enabled tarnish.service 2> /dev/null; then
+        if systemctl --quiet is-enabled tarnish.service 2>/dev/null; then
             systemctl disable tarnish.service
         fi
     fi
@@ -229,11 +229,11 @@ oxide_display() {
 
     predeinstall() {
         set -e
-        if [ "$(systemctl --quiet list-unit-files blight.service | /bin/grep -c blight.service 2> /dev/null)" -eq 1 ]; then
-            if systemctl --quiet is-active blight.service 2> /dev/null; then
+        if [ "$(systemctl --quiet list-unit-files blight.service | /bin/grep -c blight.service 2>/dev/null)" -eq 1 ]; then
+            if systemctl --quiet is-active blight.service 2>/dev/null; then
                 systemctl stop blight.service
             fi
-            if systemctl --quiet is-enabled blight.service 2> /dev/null; then
+            if systemctl --quiet is-enabled blight.service 2>/dev/null; then
                 systemctl disable blight.service
             fi
         fi
@@ -646,7 +646,7 @@ launcherctl() {
     }
     postdeinstall() {
         set -e
-        if [ "$(systemctl --quiet list-unit-files xochitl.service | /bin/grep -c xochitl.service 2> /dev/null)" -ne 1 ]; then
+        if [ "$(systemctl --quiet list-unit-files xochitl.service | /bin/grep -c xochitl.service 2>/dev/null)" -ne 1 ]; then
             systemctl enable --now xochitl
         fi
     }

--- a/applications/system-service/controller.h
+++ b/applications/system-service/controller.h
@@ -4,10 +4,14 @@
 #include <liboxide/devicesettings.h>
 #include <liboxide/oxideqml.h>
 
+#include <QFileInfo>
+#include <QFileSystemWatcher>
 #include <QKeyEvent>
 #include <QList>
 #include <QObject>
 #include <QSocketNotifier>
+#include <QTimer>
+#include <QUrl>
 
 #include <cerrno>
 #include <fcntl.h>
@@ -183,12 +187,24 @@ signals:
   void penAttached();
   void penDetached();
 
+private slots:
+  void debouncedReload(const QString& path) {
+    Q_UNUSED(path);
+    m_reloadTimer.start();
+  }
+  void reload() {
+    updateFileWatches();
+    dbusService->reload();
+  }
+
 private:
   struct SwitchMonitor {
     int fd = -1;
     QSocketNotifier* notifier = nullptr;
   };
   QList<SwitchMonitor> m_switchMonitors;
+  QFileSystemWatcher m_fileWatcher;
+  QTimer m_reloadTimer;
 
   void readEvents() {
     auto notifier = qobject_cast<QSocketNotifier*>(sender());
@@ -286,8 +302,54 @@ private:
     return path.path() == "/" ? nullptr : appsAPI->getApplication(path);
   }
 
+  void updateFileWatches() {
+    QStringList files;
+    QStringList directories;
+    for (auto& path :
+         {sharedSettings.systemOverlay(),
+          sharedSettings.notificationOverlay()}) {
+      auto url =
+        QUrl::fromUserInput(path, QDir::currentPath(), QUrl::AssumeLocalFile);
+      if (url.scheme().isEmpty()) {
+        url.setScheme("file");
+      }
+      if (!url.isLocalFile()) {
+        continue;
+      }
+      QFileInfo info(url.toLocalFile());
+      if (info.exists()) {
+        files.append(info.filePath());
+      }
+      if (info.dir().exists()) {
+        directories.append(info.dir().path());
+      }
+    }
+    for (auto& path : m_fileWatcher.files()) {
+      if (!files.contains(path)) {
+        m_fileWatcher.removePath(path);
+      }
+    }
+    for (auto& path : m_fileWatcher.directories()) {
+      if (!directories.contains(path)) {
+        m_fileWatcher.removePath(path);
+      }
+    }
+    for (auto& path : files) {
+      if (!m_fileWatcher.files().contains(path)) {
+        m_fileWatcher.addPath(path);
+      }
+    }
+    for (auto& path : directories) {
+      if (!m_fileWatcher.directories().contains(path)) {
+        m_fileWatcher.addPath(path);
+      }
+    }
+  }
+
   explicit Controller(QObject* parent = nullptr)
-    : QObject(parent) {
+    : QObject(parent)
+    , m_fileWatcher{}
+    , m_reloadTimer{} {
     connect(
       systemAPI,
       &SystemAPI::swipeLengthChanged,
@@ -361,5 +423,33 @@ private:
     });
     inputDevicesChanged();
     deviceSettings.onInputDevicesChanged([this] { inputDevicesChanged(); });
+    m_reloadTimer.setSingleShot(true);
+    m_reloadTimer.setInterval(200);
+    connect(
+      &sharedSettings,
+      &Oxide::SharedSettings::systemOverlayChanged,
+      this,
+      &Controller::debouncedReload
+    );
+    connect(
+      &sharedSettings,
+      &Oxide::SharedSettings::notificationOverlayChanged,
+      this,
+      &Controller::debouncedReload
+    );
+    connect(
+      &m_fileWatcher,
+      &QFileSystemWatcher::fileChanged,
+      this,
+      &Controller::debouncedReload
+    );
+    connect(
+      &m_fileWatcher,
+      &QFileSystemWatcher::directoryChanged,
+      this,
+      &Controller::debouncedReload
+    );
+    connect(&m_reloadTimer, &QTimer::timeout, this, &Controller::reload);
+    updateFileWatches();
   }
 };

--- a/applications/system-service/dbusservice.cpp
+++ b/applications/system-service/dbusservice.cpp
@@ -367,7 +367,9 @@ DBusService::reload() {
   auto* overlayWindow =
     qobject_cast<QQuickWindow*>(engine->rootObjects().first());
   if (!transferState(
-        qobject_cast<QQuickWindow*>(m_engine->rootObjects().first()),
+        m_engine != nullptr
+          ? qobject_cast<QQuickWindow*>(m_engine->rootObjects().first())
+          : nullptr,
         overlayWindow
       )) {
     delete engine;
@@ -420,10 +422,12 @@ DBusService::loadSystemOverlay(QQmlApplicationEngine* engine) {
     }
   }
   auto buffer = Oxide::QML::getSurfaceForWindow(window);
-  getCompositorDBus()->setFlags(
-    QString("connection/%1/surface/%2").arg(getpid()).arg(buffer->surface),
-    QStringList() << "system"
-  );
+  if (buffer != nullptr) {
+    getCompositorDBus()->setFlags(
+      QString("connection/%1/surface/%2").arg(getpid()).arg(buffer->surface),
+      QStringList() << "system"
+    );
+  }
   window->raise();
   window->show();
   return true;

--- a/applications/system-service/dbusservice.cpp
+++ b/applications/system-service/dbusservice.cpp
@@ -1,9 +1,11 @@
 #include "dbusservice.h"
 
+#include <liboxide/oxideqml.h>
 #include <mutex>
 #include <systemd/sd-daemon.h>
 
 #include "appsapi.h"
+#include "controller.h"
 #include "notificationapi.h"
 #include "powerapi.h"
 #include "screenapi.h"
@@ -301,16 +303,125 @@ DBusService::APIs() {
 }
 
 void
-DBusService::startup(QQmlApplicationEngine* engine) {
+DBusService::startup() {
 #ifdef SENTRY
   sentry_breadcrumb("dbusservice", "startup", "navigation");
 #endif
   sd_notify(0, "STATUS=startup");
+  auto* engine = new QQmlApplicationEngine();
+  if (!initializeEngine(engine)) {
+    qWarning("Failed to load main layout");
+    delete engine;
+    qApp->exit(EXIT_FAILURE);
+    return;
+  }
   m_engine = engine;
   notificationAPI->startup();
   appsAPI->startup();
   sd_notify(0, "STATUS=running");
   sd_notify(0, "READY=1");
+}
+
+bool
+transferState(QQuickWindow* oldWindow, QQuickWindow* newWindow) {
+  O_INFO("Transfering state" << oldWindow << "to" << newWindow);
+  if (newWindow == nullptr) {
+    O_WARNING("Cannot transfer state to nullptr");
+    return false;
+  }
+  if (oldWindow == nullptr) {
+    O_WARNING("No state to transfer in nullptr");
+    return true;
+  }
+  QVariant state;
+  if (!QMetaObject::invokeMethod(
+        oldWindow, "getState", Q_RETURN_ARG(QVariant, state)
+      )) {
+    O_WARNING(oldWindow << "getState method failed");
+    return true;
+  }
+  state = QVariant::fromValue(state.toMap());
+  O_INFO("State: " << state);
+  if (!QMetaObject::invokeMethod(
+        newWindow, "setState", Q_ARG(QVariant, state)
+      )) {
+    O_WARNING(newWindow << "setState method failed");
+    return false;
+  }
+  return true;
+}
+
+void
+DBusService::reload() {
+  auto* engine = new QQmlApplicationEngine();
+  if (!initializeEngine(engine)) {
+    qWarning("Failed to load main layout");
+    delete engine;
+    return;
+  }
+  auto* window = notificationAPI->loadNotificationOverlay(engine);
+  if (!transferState(notificationAPI->m_window, window)) {
+    delete engine;
+    return;
+  }
+  if (!transferState(
+        qobject_cast<QQuickWindow*>(m_engine->rootObjects().first()),
+        qobject_cast<QQuickWindow*>(engine->rootObjects().first())
+      )) {
+    delete engine;
+    return;
+  }
+  notificationAPI->m_window = window;
+  auto* oldEngine = m_engine;
+  m_engine = engine;
+  if (oldEngine != nullptr) {
+    for (auto* rootObject : oldEngine->rootObjects()) {
+      auto* window = qobject_cast<QQuickWindow*>(rootObject);
+      if (window == nullptr) {
+        continue;
+      }
+      window->lower();
+      window->close();
+    }
+    delete oldEngine;
+  }
+  O_INFO("Reload complete");
+}
+
+bool
+DBusService::initializeEngine(QQmlApplicationEngine* engine) {
+  Oxide::QML::registerQML(engine);
+  QQmlContext* context = engine->rootContext();
+  context->setContextProperty("controller", Controller::singleton());
+  return loadSystemOverlay(engine);
+}
+
+bool
+DBusService::loadSystemOverlay(QQmlApplicationEngine* engine) {
+  auto url = QUrl::fromUserInput(
+    sharedSettings.systemOverlay(), QDir::currentPath(), QUrl::AssumeLocalFile
+  );
+  if (url.scheme().isEmpty()) {
+    url.setScheme("file");
+  }
+  QWindow* window = qobject_cast<QWindow*>(Oxide::QML::loadQML(engine, url));
+  if (window == nullptr) {
+    O_WARNING("Failed to load system overlay:" << url);
+    window = qobject_cast<QWindow*>(
+      Oxide::QML::loadQML(engine, QUrl(QStringLiteral("qrc:/main.qml")))
+    );
+    if (window == nullptr) {
+      return false;
+    }
+  }
+  auto buffer = Oxide::QML::getSurfaceForWindow(window);
+  getCompositorDBus()->setFlags(
+    QString("connection/%1/surface/%2").arg(getpid()).arg(buffer->surface),
+    QStringList() << "system"
+  );
+  window->raise();
+  window->show();
+  return true;
 }
 
 void

--- a/applications/system-service/dbusservice.cpp
+++ b/applications/system-service/dbusservice.cpp
@@ -364,9 +364,11 @@ DBusService::reload() {
     delete engine;
     return;
   }
+  auto* overlayWindow =
+    qobject_cast<QQuickWindow*>(engine->rootObjects().first());
   if (!transferState(
         qobject_cast<QQuickWindow*>(m_engine->rootObjects().first()),
-        qobject_cast<QQuickWindow*>(engine->rootObjects().first())
+        overlayWindow
       )) {
     delete engine;
     return;
@@ -384,6 +386,9 @@ DBusService::reload() {
       window->close();
     }
     delete oldEngine;
+  }
+  if (overlayWindow != nullptr) {
+    overlayWindow->requestActivate();
   }
   O_INFO("Reload complete");
 }

--- a/applications/system-service/dbusservice.cpp
+++ b/applications/system-service/dbusservice.cpp
@@ -303,6 +303,24 @@ DBusService::APIs() {
 }
 
 void
+setSystemFlag(QQmlApplicationEngine* engine) {
+  for (auto* rootObject : engine->rootObjects()) {
+    auto* window = qobject_cast<QQuickWindow*>(rootObject);
+    if (window == nullptr) {
+      continue;
+    }
+    auto buffer = Oxide::QML::getSurfaceForWindow(window);
+    if (buffer == nullptr) {
+      continue;
+    }
+    getCompositorDBus()->setFlags(
+      QString("connection/%1/surface/%2").arg(getpid()).arg(buffer->surface),
+      QStringList() << "system"
+    );
+  }
+}
+
+void
 DBusService::startup() {
 #ifdef SENTRY
   sentry_breadcrumb("dbusservice", "startup", "navigation");
@@ -310,12 +328,13 @@ DBusService::startup() {
   sd_notify(0, "STATUS=startup");
   auto* engine = new QQmlApplicationEngine();
   if (!initializeEngine(engine)) {
-    qWarning("Failed to load main layout");
+    O_WARNING("Failed to load main layout");
     delete engine;
     qApp->exit(EXIT_FAILURE);
     return;
   }
   m_engine = engine;
+  setSystemFlag(m_engine);
   notificationAPI->startup();
   appsAPI->startup();
   sd_notify(0, "STATUS=running");
@@ -355,7 +374,7 @@ void
 DBusService::reload() {
   auto* engine = new QQmlApplicationEngine();
   if (!initializeEngine(engine)) {
-    qWarning("Failed to load main layout");
+    O_WARNING("Failed to load main layout");
     delete engine;
     return;
   }
@@ -385,26 +404,25 @@ DBusService::reload() {
         continue;
       }
       window->lower();
-      window->close();
+      if (!window->close()) {
+        O_WARNING("Failed to close" << window);
+      }
     }
     delete oldEngine;
   }
   if (overlayWindow != nullptr) {
     overlayWindow->requestActivate();
   }
+  setSystemFlag(m_engine);
   O_INFO("Reload complete");
 }
 
 bool
 DBusService::initializeEngine(QQmlApplicationEngine* engine) {
+  engine->clearComponentCache();
   Oxide::QML::registerQML(engine);
   QQmlContext* context = engine->rootContext();
   context->setContextProperty("controller", Controller::singleton());
-  return loadSystemOverlay(engine);
-}
-
-bool
-DBusService::loadSystemOverlay(QQmlApplicationEngine* engine) {
   auto url = QUrl::fromUserInput(
     sharedSettings.systemOverlay(), QDir::currentPath(), QUrl::AssumeLocalFile
   );

--- a/applications/system-service/dbusservice.h
+++ b/applications/system-service/dbusservice.h
@@ -41,8 +41,9 @@ public:
   QQmlApplicationEngine* engine();
 
   int tarnishPid();
-  void startup(QQmlApplicationEngine* engine);
+  void startup();
   void exit(int exitCode);
+  void reload();
 
 public slots:
   QDBusObjectPath requestAPI(QString name, QDBusMessage message);
@@ -69,6 +70,9 @@ private:
   QMap<QString, APIEntry> apis;
   bool m_exiting;
   int m_watchdogTimer;
+
+  bool initializeEngine(QQmlApplicationEngine* engine);
+  bool loadSystemOverlay(QQmlApplicationEngine* engine);
 };
 
 #endif // DBUSSERVICE_H

--- a/applications/system-service/dbusservice.h
+++ b/applications/system-service/dbusservice.h
@@ -72,7 +72,6 @@ private:
   int m_watchdogTimer;
 
   bool initializeEngine(QQmlApplicationEngine* engine);
-  bool loadSystemOverlay(QQmlApplicationEngine* engine);
 };
 
 #endif // DBUSSERVICE_H

--- a/applications/system-service/main.cpp
+++ b/applications/system-service/main.cpp
@@ -2,6 +2,7 @@
 #include <libblight/connection.h>
 #include <liboxide.h>
 #include <liboxide/oxideqml.h>
+#include <liboxide/signalhandler.h>
 
 #include <QCommandLineParser>
 #include <QGuiApplication>
@@ -12,12 +13,12 @@
 #include <QWindow>
 #include <cstdlib>
 
-#include "controller.h"
 #include "dbusservice.h"
 
 using namespace std;
 using namespace Oxide::Sentry;
 using namespace Oxide::QML;
+using namespace Oxide;
 
 const std::string runPath = "/run/oxide";
 const char* pidPath = "/run/oxide/oxide.pid";
@@ -222,31 +223,8 @@ main(int argc, char* argv[]) {
     painter.end();
     addSystemBuffer(buffer);
   }
-
-  QQmlApplicationEngine engine;
-  registerQML(&engine);
-  QTimer::singleShot(0, [&engine, &buffer] {
-    QQmlContext* context = engine.rootContext();
-    context->setContextProperty("controller", Controller::singleton());
-    auto url = QUrl::fromUserInput(
-      sharedSettings.systemOverlay(), QDir::currentPath(), QUrl::AssumeLocalFile
-    );
-    if (url.scheme().isEmpty()) {
-      url.setScheme("file");
-    }
-    QWindow* root = qobject_cast<QWindow*>(loadQML(&engine, url));
-    if (root == nullptr) {
-      O_WARNING("Failed to load system overlay:" << url);
-      root = qobject_cast<QWindow*>(
-        loadQML(&engine, QUrl(QStringLiteral("qrc:/main.qml")))
-      );
-      if (root == nullptr) {
-        qWarning("Failed to load main layout");
-        qApp->exit(EXIT_FAILURE);
-        return;
-      }
-    }
-    dbusService->startup(&engine);
+  QTimer::singleShot(0, [&buffer] {
+    dbusService->startup();
     Blight::connection()->remove(buffer);
   });
   return app.exec();

--- a/applications/system-service/main.qml
+++ b/applications/system-service/main.qml
@@ -13,6 +13,18 @@ Window{
     visible: true
     color: powerMenu.opened ? "white" : "transparent"
     property bool enableHeldKeys: controller.deviceName === "reMarkable 1"
+    function getState(){
+        return {
+            "powerMenu": powerMenu.opened
+        };
+    }
+    function setState(state){
+        window.raise()
+        window.show()
+        if(state['powerMenu']){
+            powerMenu.open()
+        }
+    }
 
     Connections{
         target: controller

--- a/applications/system-service/main.qml
+++ b/applications/system-service/main.qml
@@ -15,14 +15,16 @@ Window{
     property bool enableHeldKeys: controller.deviceName === "reMarkable 1"
     function getState(){
         return {
-            "powerMenu": powerMenu.opened
+            "powerMenu": powerMenu.opened,
+            "resumeApplication": powerMenu.resumeApplication
         };
     }
     function setState(state){
-        window.raise()
-        window.show()
+        window.raise();
+        window.show();
+        powerMenu.resumeApplication = state["resumeApplication"];
         if(state['powerMenu']){
-            powerMenu.open()
+            powerMenu.open();
         }
     }
 

--- a/applications/system-service/notification.cpp
+++ b/applications/system-service/notification.cpp
@@ -234,24 +234,22 @@ Notification::paintNotification() {
     this,
     &Notification::removed,
     this,
-    [this, window]() { nextNotification(window); },
+    [this]() { nextNotification(); },
     Qt::SingleShotConnection
   ));
   O_INFO("Painted notification" << identifier());
   emit displayed();
-  QTimer::singleShot(
-    notificationAPI->displayTime() * 1000, [this, window, connection] {
-      if (!QObject::disconnect(*connection)) {
-        return;
-      }
-      nextNotification(window);
+  QTimer::singleShot(notificationAPI->displayTime() * 1000, [this, connection] {
+    if (QObject::disconnect(*connection)) {
+      nextNotification();
     }
-  );
+  });
 }
 
 void
-Notification::nextNotification(QQuickWindow* window) {
+Notification::nextNotification() {
   O_INFO("Finished displaying notification" << identifier());
+  auto* window = notificationAPI->m_window;
   if (window != nullptr) {
     disconnect(window, SIGNAL(clicked(QString)), nullptr, nullptr);
   }

--- a/applications/system-service/notification.h
+++ b/applications/system-service/notification.h
@@ -78,7 +78,7 @@ private:
 
   bool
   hasPermission(QString permission, const char* sender = __builtin_FUNCTION());
-  void nextNotification(QQuickWindow* window);
+  void nextNotification();
 };
 
 #endif // NOTIFICATION_H

--- a/applications/system-service/notification.qml
+++ b/applications/system-service/notification.qml
@@ -23,6 +23,24 @@ Window{
     height: 500
     function orientationWidth(){ return landscape ? height : width; }
     function orientationHeight(){ return landscape ? width : height; }
+    function getState(){
+        return {
+            "text": text.text,
+            "image": image.source,
+            "notificationVisible": notification.visible,
+            "actions": actions
+        };
+    }
+    function setState(state){
+        text.text = state['text'];
+        image.source = state['image'];
+        notification.visible = state['notificationVisible'];
+        actions = state['actions'];
+        if(notification.visible){
+            window.show();
+            window.raise();
+        }
+    }
     contentOrientation: landscape ? Qt.LandscapeOrientation : Qt.PortraitOrientation
     color: "transparent"
 

--- a/applications/system-service/notificationapi.cpp
+++ b/applications/system-service/notificationapi.cpp
@@ -62,7 +62,14 @@ NotificationAPI::setEnabled(bool enabled) {
 
 void
 NotificationAPI::startup() {
-  auto engine = dbusService->engine();
+  m_window = loadNotificationOverlay(dbusService->engine());
+  if (m_window == nullptr) {
+    qFatal("Failed to load notification overlay");
+  }
+}
+
+QQuickWindow*
+NotificationAPI::loadNotificationOverlay(QQmlApplicationEngine* engine) {
   auto url = QUrl::fromUserInput(
     sharedSettings.notificationOverlay(),
     QDir::currentPath(),
@@ -71,23 +78,25 @@ NotificationAPI::startup() {
   if (url.scheme().isEmpty()) {
     url.setScheme("file");
   }
-  m_window = qobject_cast<QQuickWindow*>(Oxide::QML::loadQML(engine, url));
-  if (m_window == nullptr) {
+  auto* window = qobject_cast<QQuickWindow*>(Oxide::QML::loadQML(engine, url));
+  if (window == nullptr) {
     O_WARNING("Failed to load notification overlay:" << url);
-    m_window = qobject_cast<QQuickWindow*>(
+    window = qobject_cast<QQuickWindow*>(
       Oxide::QML::loadQML(engine, QUrl(QStringLiteral("qrc:/notification.qml")))
     );
-    if (m_window == nullptr) {
-      qFatal("Failed to load notification overlay");
+    if (window == nullptr) {
+      qWarning("Failed to load notification overlay");
+      return nullptr;
     }
   }
-  auto buffer = Oxide::QML::getSurfaceForWindow(m_window);
+  auto buffer = Oxide::QML::getSurfaceForWindow(window);
   getCompositorDBus()->setFlags(
     QString("connection/%1/surface/%2").arg(getpid()).arg(buffer->surface),
     QStringList() << "system"
   );
-  m_window->setProperty("notificationVisible", false);
-  m_window->lower();
+  window->setProperty("notificationVisible", false);
+  window->lower();
+  return window;
 }
 
 QDBusObjectPath

--- a/applications/system-service/notificationapi.cpp
+++ b/applications/system-service/notificationapi.cpp
@@ -85,7 +85,7 @@ NotificationAPI::loadNotificationOverlay(QQmlApplicationEngine* engine) {
       Oxide::QML::loadQML(engine, QUrl(QStringLiteral("qrc:/notification.qml")))
     );
     if (window == nullptr) {
-      qWarning("Failed to load notification overlay");
+      O_WARNING("Failed to load notification overlay");
       return nullptr;
     }
   }

--- a/applications/system-service/notificationapi.cpp
+++ b/applications/system-service/notificationapi.cpp
@@ -89,13 +89,6 @@ NotificationAPI::loadNotificationOverlay(QQmlApplicationEngine* engine) {
       return nullptr;
     }
   }
-  auto buffer = Oxide::QML::getSurfaceForWindow(window);
-  if (buffer != nullptr) {
-    getCompositorDBus()->setFlags(
-      QString("connection/%1/surface/%2").arg(getpid()).arg(buffer->surface),
-      QStringList() << "system"
-    );
-  }
   window->setProperty("notificationVisible", false);
   window->lower();
   return window;

--- a/applications/system-service/notificationapi.cpp
+++ b/applications/system-service/notificationapi.cpp
@@ -90,10 +90,12 @@ NotificationAPI::loadNotificationOverlay(QQmlApplicationEngine* engine) {
     }
   }
   auto buffer = Oxide::QML::getSurfaceForWindow(window);
-  getCompositorDBus()->setFlags(
-    QString("connection/%1/surface/%2").arg(getpid()).arg(buffer->surface),
-    QStringList() << "system"
-  );
+  if (buffer != nullptr) {
+    getCompositorDBus()->setFlags(
+      QString("connection/%1/surface/%2").arg(getpid()).arg(buffer->surface),
+      QStringList() << "system"
+    );
+  }
   window->setProperty("notificationVisible", false);
   window->lower();
   return window;

--- a/applications/system-service/notificationapi.h
+++ b/applications/system-service/notificationapi.h
@@ -9,6 +9,7 @@
 #include <QtDBus>
 
 #include "apibase.h"
+#include "dbusservice.h"
 #include "notification.h"
 
 #define notificationAPI NotificationAPI::singleton()
@@ -25,6 +26,8 @@ class NotificationAPI : public APIBase {
     uint displayTime READ displayTime WRITE setDisplayTime NOTIFY
       displayTimeChanged
   )
+  friend class DBusService;
+  friend class Notification;
 
 public:
   static NotificationAPI* singleton(NotificationAPI* self = nullptr);
@@ -85,6 +88,7 @@ private:
   QQuickWindow* m_window = nullptr;
 
   QString getPath(QString id);
+  QQuickWindow* loadNotificationOverlay(QQmlApplicationEngine* engine);
 };
 
 #endif // NOTIFICATIONAPI_H

--- a/applications/system-service/systemapi.cpp
+++ b/applications/system-service/systemapi.cpp
@@ -7,6 +7,7 @@
 
 #include "appsapi.h"
 #include "controller.h"
+#include "dbusservice.h"
 #include "notificationapi.h"
 #include "powerapi.h"
 #include "wifiapi.h"
@@ -908,6 +909,13 @@ SystemAPI::uninhibitPowerOff(QDBusMessage message) {
     emit powerOffInhibitedChanged(false);
   }
 }
+
+void
+SystemAPI::reload(QDBusMessage message) {
+  O_INFO("Reloading overlays");
+  dbusService->reload();
+}
+
 void
 SystemAPI::suspendTimeout() {
   if (autoSleep() && powerAPI->chargerState() != PowerAPI::ChargerConnected) {
@@ -915,6 +923,7 @@ SystemAPI::suspendTimeout() {
     suspend();
   }
 }
+
 void
 SystemAPI::lockTimeout() {
   if (autoLock()) {

--- a/applications/system-service/systemapi.h
+++ b/applications/system-service/systemapi.h
@@ -128,6 +128,7 @@ public slots:
   void inhibitPowerOff(QDBusMessage message);
   void uninhibitPowerOff(QDBusMessage message);
   void toggleSwipes();
+  void reload(QDBusMessage message);
 
 signals:
   void leftAction();

--- a/qmake/cpptrace-sentry.pri
+++ b/qmake/cpptrace-sentry.pri
@@ -2,7 +2,7 @@ contains(DEFINES, SENTRY) {
     LIBSENTRY_ROOT = $$OUT_PWD/../../shared/sentry
     LIBSENTRY_LIB = $$LIBSENTRY_ROOT/lib
     LIBSENTRY_INC = $$LIBSENTRY_ROOT/include
-    LIBS_PRIVATE += -L$$LIBSENTRY_LIB -lsentry -ldl -lcurl -lbreakpad_client
+    LIBS_PRIVATE += -L$$LIBSENTRY_LIB -lsentry -ldl -lcurl
     INCLUDEPATH += $$LIBSENTRY_INC
     DEPENDPATH += $$LIBSENTRY_LIB
 } else {

--- a/shared/liboxide/oxideqml.cpp
+++ b/shared/liboxide/oxideqml.cpp
@@ -318,10 +318,10 @@ namespace Oxide {
         } else {
           QFile file(url.toLocalFile());
           if (
-            file.exists() && file.open(
-                               QIODeviceBase::ReadOnly |
-                               QIODeviceBase::ExistingOnly | QIODevice::Text
-                             )
+            file.open(
+              QIODeviceBase::ReadOnly | QIODeviceBase::ExistingOnly |
+              QIODevice::Text
+            )
           ) {
             engine->loadData(file.readAll(), url);
           } else {

--- a/shared/liboxide/oxideqml.cpp
+++ b/shared/liboxide/oxideqml.cpp
@@ -313,7 +313,21 @@ namespace Oxide {
       timer.setInterval(30 * 1000);
       timer.callOnTimeout([&loop]() { loop.exit(1); });
       QTimer::singleShot(0, [&engine, &url, &timer]() {
-        engine->load(url);
+        if (!url.isLocalFile()) {
+          engine->load(url);
+        } else {
+          QFile file(url.toLocalFile());
+          if (
+            file.exists() && file.open(
+                               QIODeviceBase::ReadOnly |
+                               QIODeviceBase::ExistingOnly | QIODevice::Text
+                             )
+          ) {
+            engine->loadData(file.readAll(), url);
+          } else {
+            engine->load(url);
+          }
+        }
         timer.start();
       });
       QMetaObject::Connection connection;

--- a/shared/sentry/sentry.pro
+++ b/shared/sentry/sentry.pro
@@ -12,7 +12,6 @@ contains(DEFINES, SENTRY) {
             -DSENTRY_INTEGRATION_QT=ON \
             -DSENTRY_TRANSPORT=curl \
             -DSENTRY_BACKEND=inproc \
-            -DSENTRY_BREAKPAD_SYSTEM=OFF \
             -DSENTRY_SDK_NAME=sentry.native
     QMAKE_EXTRA_TARGETS += sentry_makefile
 

--- a/shared/sentry/sentry.pro
+++ b/shared/sentry/sentry.pro
@@ -11,7 +11,7 @@ contains(DEFINES, SENTRY) {
             -DSENTRY_BUILD_SHARED_LIBS=ON \
             -DSENTRY_INTEGRATION_QT=ON \
             -DSENTRY_TRANSPORT=curl \
-            -DSENTRY_BACKEND=breakpad \
+            -DSENTRY_BACKEND=inproc \
             -DSENTRY_BREAKPAD_SYSTEM=OFF \
             -DSENTRY_SDK_NAME=sentry.native
     QMAKE_EXTRA_TARGETS += sentry_makefile


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added system overlay and notification reload via D-Bus, including debounced refresh when overlay-related settings/files change.
  * Reload now preserves UI state (power menu and notifications), restoring it across overlay/appengine reloading.
* **Bug Fixes**
  * Improved QML loading robustness for local file URLs with safer read/load behavior and fallbacks.
  * Enhanced notification sequencing to avoid timing/race issues during transitions.
* **Chores**
  * Updated build/debug/sentry wiring and adjusted Sentry backend/linkage behavior; minor build script cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->