### PR TITLE
Use SleepScreenPath setting from xochitl.conf if present

### DIFF
--- a/VELBUILD
+++ b/VELBUILD
@@ -142,11 +142,11 @@ postosupgrade() {
 
 predeinstall() {
     set -e
-    if [ "$(systemctl --quiet list-unit-files tarnish.service | /bin/grep -c tarnish.service 2>/dev/null)" -eq 1 ]; then
-        if systemctl --quiet is-active tarnish.service 2>/dev/null; then
+    if [ "$(systemctl --quiet list-unit-files tarnish.service | /bin/grep -c tarnish.service 2> /dev/null)" -eq 1 ]; then
+        if systemctl --quiet is-active tarnish.service 2> /dev/null; then
             systemctl stop tarnish.service
         fi
-        if systemctl --quiet is-enabled tarnish.service 2>/dev/null; then
+        if systemctl --quiet is-enabled tarnish.service 2> /dev/null; then
             systemctl disable tarnish.service
         fi
     fi
@@ -224,11 +224,11 @@ oxide_display() {
 
     predeinstall() {
         set -e
-        if [ "$(systemctl --quiet list-unit-files blight.service | /bin/grep -c blight.service 2>/dev/null)" -eq 1 ]; then
-            if systemctl --quiet is-active blight.service 2>/dev/null; then
+        if [ "$(systemctl --quiet list-unit-files blight.service | /bin/grep -c blight.service 2> /dev/null)" -eq 1 ]; then
+            if systemctl --quiet is-active blight.service 2> /dev/null; then
                 systemctl stop blight.service
             fi
-            if systemctl --quiet is-enabled blight.service 2>/dev/null; then
+            if systemctl --quiet is-enabled blight.service 2> /dev/null; then
                 systemctl disable blight.service
             fi
         fi

--- a/applications/system-service/systemapi.cpp
+++ b/applications/system-service/systemapi.cpp
@@ -91,22 +91,24 @@ SystemAPI::PrepareForSleep(bool suspending) {
         O_INFO("Preparing for suspend...");
         Oxide::Sentry::sentry_span(
           t, "screen", "Update screen with suspend image", [this] {
-            QString path(xochitlSettings.SleepScreenPath());
-            if (path.isEmpty() || !QFile::exists(path)) {
-              path = "/usr/share/remarkable/sleeping.png";
+            QImage img;
+            for (const QString& path :
+                 {xochitlSettings.SleepScreenPath(),
+                  QStringLiteral("/usr/share/remarkable/sleeping.png"),
+                  QStringLiteral("/usr/share/remarkable/suspended.png")}) {
+              if (path.isEmpty() || !QFile::exists(path)) {
+                continue;
+              }
+              img = QImage(path);
+              if (!img.isNull()) {
+                break;
+              }
             }
-            if (!QFile::exists(path)) {
-              path = "/usr/share/remarkable/suspended.png";
-            }
-            if (!QFile::exists(path)) {
+            if (img.isNull()) {
               return;
             }
             m_buffer = createBuffer();
             if (m_buffer == nullptr) {
-              return;
-            }
-            QImage img(path);
-            if (img.isNull()) {
               return;
             }
             if (landscape()) {

--- a/applications/system-service/systemapi.cpp
+++ b/applications/system-service/systemapi.cpp
@@ -91,7 +91,10 @@ SystemAPI::PrepareForSleep(bool suspending) {
         O_INFO("Preparing for suspend...");
         Oxide::Sentry::sentry_span(
           t, "screen", "Update screen with suspend image", [this] {
-            QString path("/usr/share/remarkable/sleeping.png");
+            QString path(xochitlSettings.SleepScreenPath());
+            if (path.isEmpty() || !QFile::exists(path)) {
+              path = "/usr/share/remarkable/sleeping.png";
+            }
             if (!QFile::exists(path)) {
               path = "/usr/share/remarkable/suspended.png";
             }

--- a/shared/liboxide/xochitlsettings.cpp
+++ b/shared/liboxide/xochitlsettings.cpp
@@ -38,5 +38,6 @@ namespace Oxide {
   XochitlSettings::~XochitlSettings() {}
   O_SETTINGS_PROPERTY_BODY(XochitlSettings, QString, General, passcode)
   O_SETTINGS_PROPERTY_BODY(XochitlSettings, bool, General, wifion)
+  O_SETTINGS_PROPERTY_BODY(XochitlSettings, QString, General, SleepScreenPath)
 } // namespace Oxide
 #include "moc_xochitlsettings.cpp"

--- a/shared/liboxide/xochitlsettings.h
+++ b/shared/liboxide/xochitlsettings.h
@@ -66,6 +66,21 @@ namespace Oxide {
      */
     O_SETTINGS_PROPERTY(bool, General, wifion)
     /*!
+     * \property SleepScreenPath
+     * \brief Custom sleep screen image path
+     * \sa set_SleepScreenPath, SleepScreenPathChanged
+     */
+    /*!
+     * \fn set_SleepScreenPath
+     * \param _arg_SleepScreenPath Custom sleep screen image path
+     * \brief Set the custom sleep screen image path
+     */
+    /*!
+     * \fn SleepScreenPathChanged
+     * \brief The sleep screen image path has changed
+     */
+    O_SETTINGS_PROPERTY(QString, General, SleepScreenPath)
+    /*!
      * \property XochitlSettings::wifinetworks
      * \brief List of wifi networks
      * \sa setWifinetworks, wifinetworksChanged


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new setting to configure a custom sleep/suspend-screen image path.
  * When set, the app tries the custom image first, then falls back to the standard bundled images if the custom one is missing or can’t be loaded.

* **Bug Fixes**
  * Improved cleanup during service removal by ensuring relevant services are stopped and disabled before their unit/config files are removed and system configuration is reloaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->