### PR TITLE
Add frontlight control

### DIFF
--- a/applications/launcher/controller.h
+++ b/applications/launcher/controller.h
@@ -18,6 +18,7 @@
 
 using namespace codes::eeems::oxide1;
 using codes::eeems::oxide1::Power;
+using codes::eeems::oxide1::Frontlight;
 using Oxide::SysObject;
 using namespace Oxide::Sentry;
 
@@ -137,6 +138,11 @@ class Controller : public QObject {
   )
   Q_PROPERTY(int maxTouchWidth READ maxTouchWidth)
   Q_PROPERTY(int maxTouchHeight READ maxTouchHeight)
+  Q_PROPERTY(bool hasFrontlight READ hasFrontlight)
+  Q_PROPERTY(
+    bool extraBrightness READ extraBrightness WRITE setExtraBrightness NOTIFY
+      extraBrightnessChanged
+  )
 public:
   QObject* stateController = nullptr;
   QObject* root = nullptr;
@@ -370,6 +376,21 @@ public:
       [this](uint displayTime) { setNotificationDisplayTime(displayTime); }
     );
 
+    reply = api->requestAPI("frontlight");
+    reply.waitForFinished();
+    if (!reply.isError()) {
+      path = ((QDBusObjectPath)reply).path();
+      if (path != "/") {
+        frontlightApi = new Frontlight(OXIDE_SERVICE, path, bus);
+        connect(
+          frontlightApi,
+          &Frontlight::extraBrightnessChanged,
+          this,
+          &Controller::extraBrightnessChanged
+        );
+      }
+    }
+
     uiTimer = new QTimer(this);
     uiTimer->setSingleShot(false);
     uiTimer->setInterval(3 * 1000); // 3 seconds
@@ -525,6 +546,19 @@ public:
   bool sleepInhibited() { return systemApi->sleepInhibited(); }
   int maxTouchWidth() { return deviceSettings.getTouchWidth() * 0.9; }
   int maxTouchHeight() { return deviceSettings.getTouchHeight() * 0.9; }
+  bool hasFrontlight() { return frontlightApi != nullptr; }
+  bool extraBrightness() {
+    if (frontlightApi == nullptr) {
+      return false;
+    }
+    return frontlightApi->extraBrightness();
+  }
+  void setExtraBrightness(bool enabled) {
+    if (frontlightApi == nullptr) {
+      return;
+    }
+    frontlightApi->setExtraBrightness(enabled);
+  }
 
   Q_INVOKABLE void disconnectWifiSignals() {
     disconnect(wifiApi, &Wifi::bssFound, this, &Controller::bssFound);
@@ -598,6 +632,7 @@ signals:
   void hasNotificationChanged(bool);
   void notificationTextChanged(QString);
   void notificationsChanged(NotificationList*);
+  void extraBrightnessChanged(bool);
 
 public slots:
   void updateUIElements();
@@ -906,6 +941,7 @@ private:
   System* systemApi = nullptr;
   Apps* appsApi = nullptr;
   Notifications* notificationApi = nullptr;
+  Frontlight* frontlightApi = nullptr;
   QList<QObject*> applications;
   AppItem* getApplication(QString name);
   WifiNetworkList* networks;

--- a/applications/launcher/controller.h
+++ b/applications/launcher/controller.h
@@ -17,8 +17,8 @@
 #define OXIDE_SERVICE_PATH "/codes/eeems/oxide1"
 
 using namespace codes::eeems::oxide1;
-using codes::eeems::oxide1::Power;
 using codes::eeems::oxide1::Frontlight;
+using codes::eeems::oxide1::Power;
 using Oxide::SysObject;
 using namespace Oxide::Sentry;
 

--- a/applications/launcher/controller.h
+++ b/applications/launcher/controller.h
@@ -546,7 +546,12 @@ public:
   bool sleepInhibited() { return systemApi->sleepInhibited(); }
   int maxTouchWidth() { return deviceSettings.getTouchWidth() * 0.9; }
   int maxTouchHeight() { return deviceSettings.getTouchHeight() * 0.9; }
-  bool hasFrontlight() { return frontlightApi != nullptr; }
+  bool hasFrontlight() {
+    if (frontlightApi == nullptr) {
+      return false;
+    }
+    return frontlightApi->hasFrontlight();
+  }
   bool extraBrightness() {
     if (frontlightApi == nullptr) {
       return false;

--- a/applications/launcher/widgets/SettingsPopup.qml
+++ b/applications/launcher/widgets/SettingsPopup.qml
@@ -294,6 +294,22 @@ Item {
             RowLayout {
                 Layout.columnSpan: parent.columns
                 Layout.preferredWidth: parent.width
+                visible: controller.hasFrontlight
+                Label {
+                    text: "Extra Brightness"
+                    Layout.fillWidth: true
+                }
+                BetterCheckBox {
+                    tristate: false
+                    checkState: controller.extraBrightness ? Qt.Checked : Qt.Unchecked
+                    onClicked: controller.extraBrightness = this.checkState === Qt.Checked
+                    Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
+                    Layout.fillWidth: false
+                }
+            }
+            RowLayout {
+                Layout.columnSpan: parent.columns
+                Layout.preferredWidth: parent.width
                 Label {
                     text: "Home Screen Columns"
                     Layout.fillWidth: true

--- a/applications/settings-manager/main.cpp
+++ b/applications/settings-manager/main.cpp
@@ -43,7 +43,8 @@ main(int argc, char* argv[]) {
   parser.addVersionOption();
   parser.addPositionalArgument(
     "api",
-    "settings\nwifi\npower\napps\nsystem\nscreen\nnotification\nfrontlight\ncompositor"
+    "settings\nwifi\npower\napps\nsystem\nscreen\nnotification\nfrontlight\ncom"
+    "positor"
   );
   parser.addPositionalArgument("action", "get\nset\nlisten\ncall");
   QCommandLineOption objectOption(

--- a/applications/settings-manager/main.cpp
+++ b/applications/settings-manager/main.cpp
@@ -43,7 +43,7 @@ main(int argc, char* argv[]) {
   parser.addVersionOption();
   parser.addPositionalArgument(
     "api",
-    "settings\nwifi\npower\napps\nsystem\nscreen\nnotification\ncompositor"
+    "settings\nwifi\npower\napps\nsystem\nscreen\nnotification\nfrontlight\ncompositor"
   );
   parser.addPositionalArgument("action", "get\nset\nlisten\ncall");
   QCommandLineOption objectOption(
@@ -76,6 +76,7 @@ main(int argc, char* argv[]) {
           "system",
           "screen",
           "notification",
+          "frontlight",
           "compositor"
         })
          .contains(apiName)) {
@@ -326,6 +327,18 @@ main(int argc, char* argv[]) {
 #endif
         return qExit(EXIT_FAILURE);
       }
+    }
+  } else if (apiName == "frontlight") {
+#ifdef SENTRY
+    sentry_breadcrumb("api", "frontlight");
+#endif
+    api = new Frontlight(OXIDE_SERVICE, path, bus);
+    if (parser.isSet("object")) {
+      qDebug() << "Paths are not valid for the frontlight API";
+#ifdef SENTRY
+      sentry_breadcrumb("error", "invalid arguments");
+#endif
+      return qExit(EXIT_FAILURE);
     }
   } else if (apiName == "compositor") {
 #ifdef SENTRY

--- a/applications/system-service/controller.h
+++ b/applications/system-service/controller.h
@@ -23,12 +23,13 @@
 #include "appsapi.h"
 #include "dbusservice.h"
 #include "eventlistener.h"
+#include "frontlightapi.h"
 #include "screenapi.h"
 #include "systemapi.h"
 
 class Controller : public QObject {
   Q_OBJECT
-  Q_PROPERTY(QString deviceName READ deviceName)
+  Q_PROPERTY(QString deviceName READ deviceName CONSTANT)
   Q_PROPERTY(
     bool leftSwipeEnabled READ leftSwipeEnabled NOTIFY leftSwipeEnabledChanged
   )
@@ -53,6 +54,11 @@ class Controller : public QObject {
     int downSwipeLength READ downSwipeLength NOTIFY downSwipeLengthChanged
   )
   Q_PROPERTY(bool lidOpen READ lidOpen NOTIFY lidOpenChanged)
+  Q_PROPERTY(bool hasFrontlight READ hasFrontlight CONSTANT)
+  Q_PROPERTY(
+    int frontlightBrightness READ frontlightBrightness WRITE
+      setFrontlightBrightness NOTIFY frontlightBrightnessChanged
+  )
 
 public:
   static Controller* singleton() {
@@ -166,6 +172,13 @@ public:
     Manager* systemd = systemAPI->systemdManager();
     return systemd == nullptr || !systemd->lidClosed();
   }
+  bool hasFrontlight() {
+    return frontlightAPI->hasFrontlightNoPermissionCheck();
+  }
+  int frontlightBrightness() { return frontlightAPI->brightness(); }
+  void setFrontlightBrightness(int brightness) {
+    frontlightAPI->setBrightnessNoPermissionCheck(brightness);
+  }
   bool shouldResume() {
     auto* engine = dbusService->engine();
     if (engine == nullptr) {
@@ -211,6 +224,7 @@ signals:
   void penAttached();
   void penDetached();
   void lidOpenChanged(bool open);
+  void frontlightBrightnessChanged(int);
 
 private slots:
   void debouncedReload(const QString& path) {
@@ -478,5 +492,11 @@ private:
     );
     connect(&m_reloadTimer, &QTimer::timeout, this, &Controller::reload);
     updateFileWatches();
+    connect(
+      frontlightAPI,
+      &FrontlightAPI::brightnessChanged,
+      this,
+      &Controller::frontlightBrightnessChanged
+    );
   }
 };

--- a/applications/system-service/csl_light.h
+++ b/applications/system-service/csl_light.h
@@ -118,6 +118,9 @@ namespace csl {
         return isValid() && m_isBoosted(m_object);
       }
 
+      Manager(const Manager&) = delete;
+      Manager& operator=(const Manager&) = delete;
+
     private:
       void* m_lib = nullptr;
       void* m_object = nullptr;

--- a/applications/system-service/csl_light.h
+++ b/applications/system-service/csl_light.h
@@ -1,0 +1,135 @@
+#pragma once
+#ifdef __aarch64__
+#include <cstdlib>
+#include <cstring>
+#include <dlfcn.h>
+#include <liboxide/debug.h>
+
+namespace csl {
+  namespace light {
+    enum class Source {
+      Keyboard = 0,
+      Frontlight = 1,
+      Funkey = 2,
+    };
+
+    class Manager {
+    public:
+      Manager(Source source)
+        : m_lib(dlopen("libcsllight.so.0", RTLD_LAZY)) {
+        if (m_lib == nullptr) {
+          return;
+        }
+#define getFunc(prop, name, signature)                                         \
+  prop = reinterpret_cast<signature>(dlsym(m_lib, #name));                     \
+  if (prop == nullptr) {                                                       \
+    O_WARNING(#name " not found");                                             \
+    dlclose(m_lib);                                                            \
+    m_lib = nullptr;                                                           \
+    return;                                                                    \
+  }
+        getFunc(
+          m_constructor,
+          _ZN3csl5light7ManagerC1ENS0_6SourceE,
+          void (*)(void*, int)
+        );
+        getFunc(m_destructor, _ZN3csl5light7ManagerD1Ev, void (*)(void*));
+        getFunc(
+          m_setBrightness,
+          _ZN3csl5light7Manager13setBrightnessEi,
+          void (*)(void*, int)
+        );
+        getFunc(
+          m_getBrightness, _ZNK3csl5light7Manager10brightnessEv, int (*)(void*)
+        );
+        getFunc(
+          m_setEnabled,
+          _ZN3csl5light7Manager10setEnabledEb,
+          void (*)(void*, bool)
+        );
+        getFunc(
+          m_isEnabled, _ZNK3csl5light7Manager9isEnabledEv, bool (*)(void*)
+        );
+        getFunc(
+          m_setBoosted,
+          _ZN3csl5light7Manager20setBoostedFrontlightEb,
+          void (*)(void*, bool)
+        );
+        getFunc(
+          m_isBoosted,
+          _ZN3csl5light7Manager26isBoostedFrontlightEnabledEv,
+          bool (*)(void*)
+        );
+#undef getFunc
+        m_object = std::malloc(128);
+        if (m_object == nullptr) {
+          O_WARNING("Failed to malloc object");
+          dlclose(m_lib);
+          m_lib = nullptr;
+          return;
+        }
+        std::memset(m_object, 0, 128);
+        m_constructor(m_object, static_cast<int>(source));
+      }
+
+      ~Manager() {
+        if (m_object != nullptr && m_destructor != nullptr) {
+          m_destructor(m_object);
+        }
+        if (m_object != nullptr) {
+          std::free(m_object);
+        }
+        if (m_lib != nullptr) {
+          dlclose(m_lib);
+        }
+      }
+
+      bool isValid() const {
+        return m_lib != nullptr && m_object != nullptr;
+      }
+
+      void setBrightness(int brightness) {
+        if (isValid()) {
+          m_setBrightness(m_object, brightness);
+        }
+      }
+
+      int brightness() const {
+        return isValid() ? m_getBrightness(m_object) : 0;
+      }
+
+      void setEnabled(bool enabled) {
+        if (isValid()) {
+          m_setEnabled(m_object, enabled);
+        }
+      }
+
+      bool isEnabled() const {
+        return isValid() && m_isEnabled(m_object);
+      }
+
+      void setBoostedFrontlight(bool boosted) {
+        if (isValid()) {
+          m_setBoosted(m_object, boosted);
+        }
+      }
+
+      bool isBoostedFrontlightEnabled() {
+        return isValid() && m_isBoosted(m_object);
+      }
+
+    private:
+      void* m_lib = nullptr;
+      void* m_object = nullptr;
+      void (*m_constructor)(void*, int) = nullptr;
+      void (*m_destructor)(void*) = nullptr;
+      void (*m_setBrightness)(void*, int) = nullptr;
+      int (*m_getBrightness)(void*) = nullptr;
+      void (*m_setEnabled)(void*, bool) = nullptr;
+      bool (*m_isEnabled)(void*) = nullptr;
+      void (*m_setBoosted)(void*, bool) = nullptr;
+      bool (*m_isBoosted)(void*) = nullptr;
+    };
+  }
+}
+#endif

--- a/applications/system-service/dbusservice.cpp
+++ b/applications/system-service/dbusservice.cpp
@@ -6,6 +6,7 @@
 
 #include "appsapi.h"
 #include "controller.h"
+#include "frontlightapi.h"
 #include "notificationapi.h"
 #include "powerapi.h"
 #include "screenapi.h"
@@ -180,6 +181,18 @@ DBusService::DBusService(QObject* parent)
                   .path = QString(OXIDE_SERVICE_PATH) + "/notification",
                   .dependants = new QStringList(),
                   .instance = new NotificationAPI(this),
+                }
+              );
+            }
+          );
+          Oxide::Sentry::sentry_span(
+            s, "frontlight", "Initialize frontlight API", [this] {
+              apis.insert(
+                "frontlight",
+                APIEntry{
+                  .path = QString(OXIDE_SERVICE_PATH) + "/frontlight",
+                  .dependants = new QStringList(),
+                  .instance = new FrontlightAPI(this),
                 }
               );
             }

--- a/applications/system-service/dbusservice.h
+++ b/applications/system-service/dbusservice.h
@@ -15,6 +15,8 @@
 // Must be included so that generate_xml.sh will work
 #include "../../shared/liboxide/meta.h"
 
+#include "frontlightapi.h"
+
 #define dbusService DBusService::singleton()
 
 using namespace std;

--- a/applications/system-service/frontlightapi.cpp
+++ b/applications/system-service/frontlightapi.cpp
@@ -1,0 +1,174 @@
+#include "frontlightapi.h"
+
+#include <liboxide.h>
+#include <liboxide/devicesettings.h>
+
+FrontlightAPI*
+FrontlightAPI::singleton(FrontlightAPI* self) {
+  static FrontlightAPI* instance;
+  if (self != nullptr) {
+    instance = self;
+  }
+  return instance;
+}
+
+FrontlightAPI::FrontlightAPI(QObject* parent)
+  : APIBase(parent)
+  , m_enabled(false) {
+  Oxide::Sentry::sentry_transaction(
+    "Frontlight API Init", "init", [this](Oxide::Sentry::Transaction* t) {
+      Oxide::Sentry::sentry_span(t, "singleton", "Setup singleton", [this] {
+        singleton(this);
+      });
+      switch (deviceSettings.getDeviceType()) {
+#ifdef __aarch64__
+        case Oxide::DeviceSettings::RMPP:
+        case Oxide::DeviceSettings::RMPPM:
+          Oxide::Sentry::sentry_span(
+            t, "manager", "Create csl light manager", [this] {
+              m_manager =
+                new csl::light::Manager(csl::light::Source::Frontlight);
+              if (!m_manager->isValid()) {
+                O_WARNING("Failed to load libcsllight");
+                return;
+              }
+              O_INFO("Frontlight brightness:" << m_manager->brightness());
+            }
+          );
+          break;
+#endif
+        default:
+          O_INFO("No frontlight");
+          return;
+      }
+    }
+  );
+}
+
+FrontlightAPI::~FrontlightAPI() {
+#ifdef __aarch64__
+  if (m_manager != nullptr) {
+    delete m_manager;
+  }
+#endif
+}
+
+void
+FrontlightAPI::setEnabled(bool enabled) {
+  m_enabled = enabled;
+  O_INFO("Frontlight API" << enabled);
+}
+
+bool
+FrontlightAPI::getHasFrontlight() {
+  return hasPermission("frontlight") && hasFrontlightNoPermissionCheck();
+}
+
+bool
+FrontlightAPI::hasFrontlightNoPermissionCheck() {
+#ifdef __aarch64__
+  if (m_manager == nullptr || !m_manager->isValid()) {
+    return false;
+  }
+  switch (deviceSettings.getDeviceType()) {
+    case Oxide::DeviceSettings::RMPP:
+    case Oxide::DeviceSettings::RMPPM:
+      return true;
+    default:
+      return false;
+  }
+#else
+  return false;
+#endif
+}
+
+int
+FrontlightAPI::getBrightness() {
+  if (!hasPermission("frontlight")) {
+    return 0;
+  }
+  return brightness();
+}
+
+int
+FrontlightAPI::brightness() {
+#ifdef __aarch64__
+  if (!hasFrontlightNoPermissionCheck() || !m_manager->isEnabled()) {
+    return 0;
+  }
+  return m_manager->brightness();
+#else
+  return 0;
+#endif
+}
+
+void
+FrontlightAPI::setBrightness(int brightness) {
+  if (!hasPermission("frontlight")) {
+    return;
+  }
+  setBrightnessNoPermissionCheck(brightness);
+}
+
+void
+FrontlightAPI::setBrightnessNoPermissionCheck(int brightness) {
+#ifdef __aarch64__
+  if (!hasFrontlightNoPermissionCheck()) {
+    return;
+  }
+  if (m_manager == nullptr || !m_manager->isValid()) {
+    return;
+  }
+  brightness = qBound(0, brightness, 100);
+  O_DEBUG("Frontlight brightness:" << brightness);
+  m_manager->setEnabled(brightness > 0);
+  m_manager->setBrightness(brightness);
+  if (m_enabled) {
+    emit brightnessChanged(brightness);
+  }
+#endif
+}
+
+bool
+FrontlightAPI::getExtraBrightness() {
+  if (!hasPermission("frontlight")) {
+    return false;
+  }
+  return extraBrightness();
+}
+
+bool
+FrontlightAPI::extraBrightness() {
+#ifdef __aarch64__
+  return hasFrontlightNoPermissionCheck() && m_manager != nullptr &&
+         m_manager->isValid() && m_manager->isBoostedFrontlightEnabled();
+#else
+  return false;
+#endif
+}
+
+void
+FrontlightAPI::setExtraBrightness(bool enabled) {
+  if (!hasPermission("frontlight")) {
+    return;
+  }
+  setExtraBrightnessNoPermissionCheck(enabled);
+}
+
+void
+FrontlightAPI::setExtraBrightnessNoPermissionCheck(bool enabled) {
+#ifdef __aarch64__
+  if (!hasFrontlightNoPermissionCheck()) {
+    return;
+  }
+  O_INFO("Frontlight extra brightness:" << enabled);
+  if (m_manager != nullptr && m_manager->isValid()) {
+    m_manager->setBoostedFrontlight(enabled);
+  }
+  if (m_enabled) {
+    emit extraBrightnessChanged(enabled);
+  }
+#endif
+}
+
+#include "moc_frontlightapi.cpp"

--- a/applications/system-service/frontlightapi.h
+++ b/applications/system-service/frontlightapi.h
@@ -14,7 +14,8 @@ class FrontlightAPI : public APIBase {
   Q_OBJECT
   Q_CLASSINFO("D-Bus Interface", OXIDE_FRONTLIGHT_INTERFACE)
   Q_PROPERTY(
-    int brightness READ getBrightness WRITE setBrightness NOTIFY brightnessChanged
+    int brightness READ getBrightness WRITE setBrightness NOTIFY
+      brightnessChanged
   )
   Q_PROPERTY(bool hasFrontlight READ getHasFrontlight)
   Q_PROPERTY(

--- a/applications/system-service/frontlightapi.h
+++ b/applications/system-service/frontlightapi.h
@@ -1,0 +1,53 @@
+#ifndef FRONTLIGHTAPI_H
+#define FRONTLIGHTAPI_H
+
+#include "csl_light.h"
+#include <liboxide.h>
+
+#include <QObject>
+
+#include "apibase.h"
+
+#define frontlightAPI FrontlightAPI::singleton()
+
+class FrontlightAPI : public APIBase {
+  Q_OBJECT
+  Q_CLASSINFO("D-Bus Interface", OXIDE_FRONTLIGHT_INTERFACE)
+  Q_PROPERTY(
+    int brightness READ getBrightness WRITE setBrightness NOTIFY brightnessChanged
+  )
+  Q_PROPERTY(bool hasFrontlight READ getHasFrontlight)
+  Q_PROPERTY(
+    bool extraBrightness READ getExtraBrightness WRITE setExtraBrightness NOTIFY
+      extraBrightnessChanged
+  )
+
+public:
+  static FrontlightAPI* singleton(FrontlightAPI* self = nullptr);
+  FrontlightAPI(QObject* parent);
+  ~FrontlightAPI();
+  void setEnabled(bool enabled) override;
+
+  int getBrightness();
+  int brightness();
+  void setBrightness(int brightness);
+  void setBrightnessNoPermissionCheck(int brightness);
+  bool getHasFrontlight();
+  bool hasFrontlightNoPermissionCheck();
+  bool getExtraBrightness();
+  bool extraBrightness();
+  void setExtraBrightness(bool enabled);
+  void setExtraBrightnessNoPermissionCheck(bool enabled);
+
+signals:
+  void brightnessChanged(int);
+  void extraBrightnessChanged(bool);
+
+private:
+  bool m_enabled = false;
+#ifdef __aarch64__
+  csl::light::Manager* m_manager = nullptr;
+#endif
+};
+
+#endif // FRONTLIGHTAPI_H

--- a/applications/system-service/main.qml
+++ b/applications/system-service/main.qml
@@ -235,6 +235,46 @@ Window{
             }
         }
         contentItem: ColumnLayout {
+            spacing: 10
+            Slider {
+                id: brightnessSlider
+                visible: controller.hasFrontlight
+                Layout.fillWidth: true
+                Layout.preferredHeight: 60
+                from: 0
+                to: 100
+                value: controller.frontlightBrightness
+                onMoved: controller.frontlightBrightness = value
+                background: Rectangle {
+                    x: brightnessSlider.leftPadding
+                    y: brightnessSlider.topPadding + brightnessSlider.availableHeight / 2 - height / 2
+                    width: brightnessSlider.availableWidth
+                    height: 8
+                    color: "black"
+                }
+                handle: Rectangle {
+                    x: brightnessSlider.leftPadding + brightnessSlider.visualPosition * (brightnessSlider.availableWidth - width)
+                    y: brightnessSlider.topPadding + brightnessSlider.availableHeight / 2 - height / 2
+                    width: 50
+                    height: 50
+                    radius: 25
+                    color: "white"
+                    border.color: "black"
+                    border.width: 2
+                }
+            }
+            Label {
+                text: "Brightness"
+                visible: controller.hasFrontlight
+                Layout.fillWidth: true
+                font.pixelSize: 36
+                horizontalAlignment: Text.AlignRight
+            }
+            Item {
+                visible: controller.hasFrontlight
+                Layout.fillWidth: true
+                Layout.preferredHeight: 20
+            }
             OxideButton {
                 text: "Suspend"
                 Layout.fillWidth: true

--- a/applications/system-service/system-service.pro
+++ b/applications/system-service/system-service.pro
@@ -15,6 +15,7 @@ SOURCES += \
     bss.cpp \
     dbusservice.cpp \
     eventlistener.cpp \
+    frontlightapi.cpp \
     network.cpp \
     notification.cpp \
     notificationapi.cpp \
@@ -73,8 +74,10 @@ HEADERS += \
     appsapi.h \
     bss.h \
     controller.h \
+    csl_light.h \
     dbusservice.h \
     eventlistener.h \
+    frontlightapi.h \
     network.h \
     notification.h \
     notificationapi.h \

--- a/applications/system-service/systemapi.cpp
+++ b/applications/system-service/systemapi.cpp
@@ -8,6 +8,7 @@
 #include "appsapi.h"
 #include "controller.h"
 #include "dbusservice.h"
+#include "frontlightapi.h"
 #include "notificationapi.h"
 #include "powerapi.h"
 #include "wifiapi.h"
@@ -25,7 +26,7 @@ operator<<(QDebug debug, Touch* touch) {
   return debug.maybeSpace();
 }
 #ifdef __aarch64__
-void
+static void
 disableVPDD() {
   QString basePath;
   switch (deviceSettings.getDeviceType()) {
@@ -45,35 +46,6 @@ disableVPDD() {
       "Cancelled VPDD timer at" << device.propertyPath("vpdd_length").c_str()
     );
   }
-}
-#endif
-
-#ifdef __aarch64__
-static void
-saveBacklight(const char* backlight, const char* cslSource, int& savedValue) {
-  QString sysPath = QStringLiteral("/sys/class/backlight/") + backlight;
-  if (!QFile::exists(sysPath)) {
-    return;
-  }
-  savedValue = Oxide::SysObject(sysPath).intProperty("brightness");
-  O_DEBUG("Saved" << cslSource << "brightness:" << savedValue);
-  QProcess::execute(
-    "csl",
-    QStringList() << "light" << "--source" << cslSource << "--brightness" << "0"
-  );
-  O_DEBUG("Turned off" << cslSource << "backlight for suspend");
-}
-
-static void
-restoreBacklight(const char* backlight, const char* cslSource, int savedValue) {
-  QString sysPath = QStringLiteral("/sys/class/backlight/") + backlight;
-  if (savedValue <= 0 || !QFile::exists(sysPath)) {
-    return;
-  }
-  SysObject sysObject(sysPath);
-  sysObject.setProperty("brightness", std::to_string(savedValue));
-  sysObject.setProperty("bl_power", "0");
-  O_DEBUG("Restored" << cslSource << "brightness:" << savedValue);
 }
 #endif
 
@@ -177,13 +149,31 @@ SystemAPI::PrepareForSleep(bool suspending) {
             }
 #ifdef __aarch64__
             disableVPDD();
-            saveBacklight(
-              "rm_frontlight", "frontlight", m_savedFrontlightBrightness
-            );
-            saveBacklight(
-              "rm_keyboard_backlight", "keyboard", m_savedKeyboardBrightness
-            );
 #endif
+            {
+              auto* api = FrontlightAPI::singleton();
+              if (api->hasFrontlightNoPermissionCheck()) {
+                m_savedFrontlightBrightness = api->brightness();
+                O_DEBUG(
+                  "Saved frontlight brightness:" << m_savedFrontlightBrightness
+                );
+                api->setBrightnessNoPermissionCheck(0);
+                O_DEBUG("Turned off frontlight for suspend");
+              }
+            }
+            {
+              QString sysPath =
+                QStringLiteral("/sys/class/backlight/rm_keyboard_backlight");
+              if (QFile::exists(sysPath)) {
+                m_savedKeyboardBrightness =
+                  Oxide::SysObject(sysPath).intProperty("brightness");
+                O_DEBUG(
+                  "Saved keyboard brightness:" << m_savedKeyboardBrightness
+                );
+                Oxide::SysObject(sysPath).setProperty("brightness", "0");
+                O_DEBUG("Turned off keyboard backlight for suspend");
+              }
+            }
             releaseSleepInhibitors();
           }
         );
@@ -208,14 +198,29 @@ SystemAPI::PrepareForSleep(bool suspending) {
         Oxide::Sentry::sentry_span(t, "inhibit", "Inhibit sleep", [this] {
           inhibitSleep();
         });
-#ifdef __aarch64__
-        restoreBacklight(
-          "rm_frontlight", "frontlight", m_savedFrontlightBrightness
-        );
-        restoreBacklight(
-          "rm_keyboard_backlight", "keyboard", m_savedKeyboardBrightness
-        );
-#endif
+        {
+          auto* api = FrontlightAPI::singleton();
+          if (api->hasFrontlightNoPermissionCheck() && m_savedFrontlightBrightness > 0) {
+            api->setBrightnessNoPermissionCheck(m_savedFrontlightBrightness);
+            O_DEBUG(
+              "Restored frontlight brightness:" << m_savedFrontlightBrightness
+            );
+          }
+        }
+        {
+          QString sysPath =
+            QStringLiteral("/sys/class/backlight/rm_keyboard_backlight");
+          if (m_savedKeyboardBrightness > 0 && QFile::exists(sysPath)) {
+            Oxide::SysObject sysObject(sysPath);
+            sysObject.setProperty(
+              "brightness", std::to_string(m_savedKeyboardBrightness)
+            );
+            sysObject.setProperty("bl_power", "0");
+            O_DEBUG(
+              "Restored keyboard brightness:" << m_savedKeyboardBrightness
+            );
+          }
+        }
         Oxide::Sentry::sentry_span(
           t,
           "resume",

--- a/applications/system-service/systemapi.cpp
+++ b/applications/system-service/systemapi.cpp
@@ -200,7 +200,10 @@ SystemAPI::PrepareForSleep(bool suspending) {
         });
         {
           auto* api = FrontlightAPI::singleton();
-          if (api->hasFrontlightNoPermissionCheck() && m_savedFrontlightBrightness > 0) {
+          if (
+            api->hasFrontlightNoPermissionCheck() &&
+            m_savedFrontlightBrightness > 0
+          ) {
             api->setBrightnessNoPermissionCheck(m_savedFrontlightBrightness);
             O_DEBUG(
               "Restored frontlight brightness:" << m_savedFrontlightBrightness

--- a/applications/system-service/systemapi.h
+++ b/applications/system-service/systemapi.h
@@ -167,10 +167,8 @@ private:
   QMutex mutex;
   bool reSuspend;
   bool wifiWasOn;
-#ifdef __aarch64__
   int m_savedFrontlightBrightness = 0;
   int m_savedKeyboardBrightness = 0;
-#endif
   QMap<SwipeDirection, bool> swipeStates;
   QMap<SwipeDirection, int> swipeLengths;
   Blight::shared_buf_t m_buffer = nullptr;

--- a/applications/xdg-settings/main.cpp
+++ b/applications/xdg-settings/main.cpp
@@ -17,6 +17,7 @@ const QSet<QString> ApiNames = QSet<QString>{
   "system",
   "screen",
   "notification",
+  "frontlight",
 };
 
 QTextStream&
@@ -67,6 +68,9 @@ getApi(const QString& name) {
   }
   if (name == "notification") {
     return new Notifications(OXIDE_SERVICE, path, bus);
+  }
+  if (name == "frontlight") {
+    return new Frontlight(OXIDE_SERVICE, path, bus);
   }
   qDebug() << "xdg-settings: Unknown API" << name;
   return nullptr;

--- a/assets/etc/dbus-1/system.d/codes.eeems.oxide.conf
+++ b/assets/etc/dbus-1/system.d/codes.eeems.oxide.conf
@@ -32,5 +32,7 @@
     <allow receive_interface="codes.eeems.oxide1.Notifications" receive_path="*" receive_member="*"/>
     <allow send_interface="codes.eeems.oxide1.Notification" send_path="*" send_member="*"/>
     <allow receive_interface="codes.eeems.oxide1.Notification" receive_path="*" receive_member="*"/>
+    <allow send_interface="codes.eeems.oxide1.Frontlight" send_path="*" send_member="*"/>
+    <allow receive_interface="codes.eeems.oxide1.Frontlight" receive_path="*" receive_member="*"/>
   </policy>
 </busconfig>

--- a/assets/opt/usr/share/applications/codes.eeems.oxide.oxide
+++ b/assets/opt/usr/share/applications/codes.eeems.oxide.oxide
@@ -4,5 +4,5 @@
     "bin": "/home/root/.vellum/bin/oxide",
     "type": "foreground",
     "flags": ["hidden", "nopreload"],
-    "permissions": ["apps", "wifi", "power", "system", "notification"]
+    "permissions": ["apps", "wifi", "power", "system", "notification", "frontlight"]
 }

--- a/interfaces/frontlightapi.xml
+++ b/interfaces/frontlightapi.xml
@@ -1,0 +1,14 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+  <interface name="codes.eeems.oxide1.Frontlight">
+    <property name="brightness" type="i" access="readwrite"/>
+    <property name="hasFrontlight" type="b" access="read"/>
+    <property name="extraBrightness" type="b" access="readwrite"/>
+    <signal name="brightnessChanged">
+      <arg type="i" direction="out"/>
+    </signal>
+    <signal name="extraBrightnessChanged">
+      <arg type="b" direction="out"/>
+    </signal>
+  </interface>
+</node>

--- a/interfaces/systemapi.xml
+++ b/interfaces/systemapi.xml
@@ -67,6 +67,8 @@
     </method>
     <method name="toggleSwipes">
     </method>
+    <method name="reload">
+    </method>
     <method name="setSwipeEnabled">
       <arg name="direction" type="i" direction="in"/>
       <arg name="enabled" type="b" direction="in"/>

--- a/shared/liboxide/dbus.h
+++ b/shared/liboxide/dbus.h
@@ -64,6 +64,10 @@ namespace codes::eeems::oxide1 {
    * \brief The Notification class
    */
   class Notification : public QDBusAbstractInterface {};
+  /*!
+   * \brief The Frontlight class
+   */
+  class Frontlight : public QDBusAbstractInterface {};
 } // namespace codes::eeems::oxide1
 #endif
 #include "application_interface.h"
@@ -78,6 +82,7 @@ namespace codes::eeems::oxide1 {
 #include "screenshot_interface.h"
 #include "systemapi_interface.h"
 #include "wifiapi_interface.h"
+#include "frontlightapi_interface.h"
 #ifdef IN_DOXYGEN
 /*!
  * \brief Display server DBus interfaces

--- a/shared/liboxide/dbus.h
+++ b/shared/liboxide/dbus.h
@@ -74,6 +74,7 @@ namespace codes::eeems::oxide1 {
 #include "appsapi_interface.h"
 #include "bss_interface.h"
 #include "dbusservice_interface.h"
+#include "frontlightapi_interface.h"
 #include "network_interface.h"
 #include "notification_interface.h"
 #include "notificationapi_interface.h"
@@ -82,7 +83,6 @@ namespace codes::eeems::oxide1 {
 #include "screenshot_interface.h"
 #include "systemapi_interface.h"
 #include "wifiapi_interface.h"
-#include "frontlightapi_interface.h"
 #ifdef IN_DOXYGEN
 /*!
  * \brief Display server DBus interfaces

--- a/shared/liboxide/liboxide.pro
+++ b/shared/liboxide/liboxide.pro
@@ -80,7 +80,8 @@ DBUS_INTERFACES += \
     ../../interfaces/screenapi.xml \
     ../../interfaces/screenshot.xml \
     ../../interfaces/notificationapi.xml \
-    ../../interfaces/notification.xml
+    ../../interfaces/notification.xml \
+    ../../interfaces/frontlightapi.xml
 
 blight.files = ../../interfaces/blight.xml
 blight.header_flags = -i dbus_types.h

--- a/shared/liboxide/meta.h
+++ b/shared/liboxide/meta.h
@@ -96,4 +96,9 @@
  * \brief DBus service for a screenshot object
  */
 #define OXIDE_SCREENSHOT_INTERFACE OXIDE_SERVICE ".Screenshot"
+/*!
+ * \def OXIDE_FRONTLIGHT_INTERFACE
+ * \brief DBus service for the frontlight API
+ */
+#define OXIDE_FRONTLIGHT_INTERFACE OXIDE_SERVICE ".Frontlight"
 /*! @} */

--- a/web/src/documentation/api/08_frontlight.rst
+++ b/web/src/documentation/api/08_frontlight.rst
@@ -1,0 +1,81 @@
+==============
+Frontlight API
+==============
+
+.. note::
+
+  The Frontlight API is only available on devices with a frontlight
+  (reMarkable Paper Pro and reMarkable Paper Pro Move).
+
++------------------------+----------------------+----------------------+
+| Name                   | Specification        | Description          |
++========================+======================+======================+
+| brightness             | ``INT32`` property   | Current frontlight   |
+|                        | (read/write)         | brightness level.    |
+|                        |                      | Range is ``0`` to    |
+|                        |                      | ``100``. Setting     |
+|                        |                      | to ``0`` disables    |
+|                        |                      | the frontlight.      |
++------------------------+----------------------+----------------------+
+| hasFrontlight          | ``BOOLEAN`` property | Whether the device   |
+|                        | (read)               | has a frontlight.    |
++------------------------+----------------------+----------------------+
+| extraBrightness        | ``BOOLEAN`` property | Whether extra        |
+|                        | (read/write)         | brightness mode is   |
+|                        |                      | enabled.             |
++------------------------+----------------------+----------------------+
+| brightnessChanged      | signal               | Signal sent when the |
+|                        |                      | brightness has       |
+|                        | - (out) ``INT32``    | changed.             |
++------------------------+----------------------+----------------------+
+| extraBrightnessChanged | signal               | Signal sent when the |
+|                        |                      | extraBrightness has  |
+|                        | - (out) ``BOOLEAN``  | changed.             |
++------------------------+----------------------+----------------------+
+
+.. note::
+
+  All methods and property writes on the Frontlight API require the
+  ``frontlight`` permission.
+
+.. _example-usage-frontlight:
+
+Example Usage
+~~~~~~~~~~~~~
+
+.. code:: cpp
+
+   #include <liboxide/dbus.h>
+
+   using namespace codes::eeems::oxide1;
+
+   int main(int argc, char* argv[]){
+       QCoreApplication app(argc, argv);
+
+       auto bus = QDBusConnection::systemBus();
+       General api(OXIDE_SERVICE, OXIDE_SERVICE_PATH, bus);
+       qDebug() << "Requesting frontlight API...";
+       QDBusObjectPath path = api.requestAPI("frontlight");
+       if(path.path() == "/"){
+           qDebug() << "Unable to get frontlight API";
+           return EXIT_FAILURE;
+       }
+       qDebug() << "Got the frontlight API!";
+
+       Frontlight frontlight(OXIDE_SERVICE, path.path(), bus);
+       if(!frontlight.hasFrontlight()){
+           qDebug() << "Device does not have a frontlight";
+           return EXIT_FAILURE;
+       }
+       qDebug() << "Current brightness:" << frontlight.brightness();
+       frontlight.setBrightness(50);
+       return app.exec();
+   }
+
+.. code:: shell
+
+   #!/bin/bash
+   echo "Current brightness:"
+   rot frontlight get brightness
+   echo "Setting brightness to 50:"
+   rot frontlight set brightness 50


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added frontlight brightness control to the power menu when supported.
  * Added “Extra Brightness” option in launcher settings.
  * Enabled frontlight support across system and API tooling, including discoverability and state updates.
* **Bug Fixes**
  * Frontlight and keyboard backlight are now switched off during suspend and restored after resume.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->